### PR TITLE
Retina screen support for custom icon images.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,4 +11,5 @@
 
 Son Nguyen <sonnguyen@google.com>
 Brett Morgan <brettmorgan@google.com>
+Michael Lapuebla <chainedtothewoods@gmail.com>
 

--- a/src/Clustering/View/GMUDefaultClusterIconGenerator.m
+++ b/src/Clustering/View/GMUDefaultClusterIconGenerator.m
@@ -126,7 +126,7 @@ static NSArray<UIColor *> *kGMUBucketBackgroundColors;
 
   UIFont *font = [UIFont boldSystemFontOfSize:12];
   CGSize size = image.size;
-  UIGraphicsBeginImageContext(size);
+  UIGraphicsBeginImageContextWithOptions(size, NO, 0.0f);
   [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
   CGRect rect = CGRectMake(0, 0, image.size.width, image.size.height);
 


### PR DESCRIPTION
Improved pixel clarity of text and custom base images for clusters on Retina and Retina+ screens.


Before:
![simulator screen shot aug 25 2016 11 36 08 pm](https://cloud.githubusercontent.com/assets/20367523/17996320/d8795cfa-6b1c-11e6-937c-38e0f2de1d9e.png)

After:
![simulator screen shot aug 25 2016 11 36 26 pm](https://cloud.githubusercontent.com/assets/20367523/17996324/ddb788c2-6b1c-11e6-8321-848d6e54f605.png)


