### PR TITLE
Allow GMUDefaultClusterRenderer to utilize the zIndex property for clusters.

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.h
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If no specific zIndex is not specified during the initialization, the
  * default zIndex is '1'.  Larger zIndex values are drawn over lower ones
  * similar to the zIndex value of GMSMarkers.
- */@property(nonatomic) float zIndex;
+ */@property(nonatomic) int zIndex;
 
 - (instancetype)initWithMapView:(GMSMapView *)mapView
            clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;

--- a/src/Clustering/View/GMUDefaultClusterRenderer.h
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.h
@@ -57,21 +57,19 @@ NS_ASSUME_NONNULL_BEGIN
  * Default to YES.
  */@property(nonatomic) BOOL animatesClusters;
 
-- (instancetype)initWithMapView:(GMSMapView *)mapView
-           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;
-
 /**
  * Allows setting a zIndex value for the clusters.  This becomes useful
  * when using multiple cluster data sets on the map and require a predictable
  * way of displaying multiple sets with a predictable layering order.
  *
- * If no specific zIndex is not specified during the initialization, the 
+ * If no specific zIndex is not specified during the initialization, the
  * default zIndex is '1'.  Larger zIndex values are drawn over lower ones
  * similar to the zIndex value of GMSMarkers.
- */
+ */@property(nonatomic) float zIndex;
+
 - (instancetype)initWithMapView:(GMSMapView *)mapView
-           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator
-                         zIndex:(float)zIndex;
+           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;
+
 /**
  * If returns NO, cluster items will be expanded and rendered as normal markers.
  * Subclass can override this method to provide custom logic.

--- a/src/Clustering/View/GMUDefaultClusterRenderer.h
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.h
@@ -61,6 +61,18 @@ NS_ASSUME_NONNULL_BEGIN
            clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;
 
 /**
+ * Allows setting a zIndex value for the clusters.  This becomes useful
+ * when using multiple cluster data sets on the map and require a predictable
+ * way of displaying multiple sets with a predictable layering order.
+ *
+ * If no specific zIndex is not specified during the initialization, the 
+ * default zIndex is '1'.  Larger zIndex values are drawn over lower ones
+ * similar to the zIndex value of GMSMarkers.
+ */
+- (instancetype)initWithMapView:(GMSMapView *)mapView
+           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator
+                         zIndex:(float)zIndex;
+/**
  * If returns NO, cluster items will be expanded and rendered as normal markers.
  * Subclass can override this method to provide custom logic.
  */

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -55,9 +55,6 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
   // Stores previous zoom level to determine zooming direction (in/out).
   float _previousZoom;
-    
-  // Allows clusters to utilize a zIndex value.
-  float _zIndex;
 
   // Lookup map from cluster item to an old cluster.
   NSMutableDictionary<GMUWrappingDictionaryKey *, id<GMUCluster>> *_itemToOldClusterMap;

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -80,15 +80,6 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
   return self;
 }
 
-- (instancetype)initWithMapView:(GMSMapView *)mapView
-           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator
-                         zIndex:(float)zIndex {
-  if ((self = [self initWithMapView:mapView clusterIconGenerator:iconGenerator])) {
-    _zIndex = zIndex;
-  }
-  return self;
-}
-
 - (void)dealloc {
   [self clear];
 }

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -55,6 +55,9 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
   // Stores previous zoom level to determine zooming direction (in/out).
   float _previousZoom;
+    
+  // Allows clusters to utilize a zIndex value.
+  float _zIndex;
 
   // Lookup map from cluster item to an old cluster.
   NSMutableDictionary<GMUWrappingDictionaryKey *, id<GMUCluster>> *_itemToOldClusterMap;
@@ -72,6 +75,16 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     _renderedClusters = [[NSMutableSet alloc] init];
     _renderedClusterItems = [[NSMutableSet alloc] init];
     _animatesClusters = YES;
+    _zIndex = 1;
+  }
+  return self;
+}
+
+- (instancetype)initWithMapView:(GMSMapView *)mapView
+           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator
+                         zIndex:(float)zIndex {
+  if ((self = [self initWithMapView:mapView clusterIconGenerator:iconGenerator])) {
+    _zIndex = zIndex;
   }
   return self;
 }
@@ -299,6 +312,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     marker.icon = clusterIcon;
     marker.groundAnchor = CGPointMake(0.5, 0.5);
   }
+  marker.zIndex = _zIndex;
   marker.map = _mapView;
 
   if (animated) {


### PR DESCRIPTION
Allow GMUDefaultClusterRenderer to utilize the zIndex property for clusters.

This proves to be useful when using multiple GMUClusterManagers in a single map and allows a predictable drawing priority per cluster manager.

Example:
The blue clusters have a higher zIndex precedence than the grey cluster icon.  The 'blue' clusters are drawn on top regardless of zoom, pan or scroll.

<img width="304" alt="screen shot 2016-08-26 at 2 48 42 am" src="https://cloud.githubusercontent.com/assets/20367523/18001421/ca18eb38-6b37-11e6-8bc0-94af2e5c4f47.png">
