### PR TITLE
Fix Xcode Analyser warning by removing nullable (default) initializer

### DIFF
--- a/src/Clustering/GMUClusterManager+Testing.h
+++ b/src/Clustering/GMUClusterManager+Testing.h
@@ -15,9 +15,14 @@
 
 #import "GMUClusterManager.h"
 
-/* Extensions for testing purposes only. */
+/** 
+ * Extensions for testing purposes only. 
+ */
 @interface GMUClusterManager (Testing)
 
+/**
+ * Returns in number of cluster requests.
+ */
 - (NSUInteger)clusterRequestCount;
 
 @end

--- a/src/Clustering/GMUClusterManager.h
+++ b/src/Clustering/GMUClusterManager.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
                    renderer:(id<GMUClusterRenderer>)renderer;
 
 /** Gets the clustering algorithm. */
-@property(nonatomic, readonly) id<GMUClusterAlgorithm> algorithm;
+@property(nonatomic, readonly, nullable) id<GMUClusterAlgorithm> algorithm;
 
 /**
  * GMUClusterManager |delegate|.

--- a/src/Clustering/GMUClusterManager.h
+++ b/src/Clustering/GMUClusterManager.h
@@ -45,13 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GMUClusterManager : NSObject<GMSMapViewDelegate>
 
+/** Disallow default initializer */
+- (id)init __attribute__((unavailable("Use initWithMap:algorithm:renderer: instead.")));
+
 /** Initializer with the |mapView|, |algorithm| and |renderer|. */
 - (instancetype)initWithMap:(GMSMapView *)mapView
                   algorithm:(id<GMUClusterAlgorithm>)algorithm
                    renderer:(id<GMUClusterRenderer>)renderer;
 
 /** Gets the clustering algorithm. */
-@property(nonatomic, readonly, nullable) id<GMUClusterAlgorithm> algorithm;
+@property(nonatomic, readonly) id<GMUClusterAlgorithm> algorithm;
 
 /**
  * GMUClusterManager |delegate|.

--- a/src/Clustering/GMUClusterManager.h
+++ b/src/Clustering/GMUClusterManager.h
@@ -25,17 +25,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class GMUClusterManager;
 
-/** Delegate for events on GMUClusterManager. */
+/** 
+ * Delegate for events on the GMUClusterManager. 
+ */
 @protocol GMUClusterManagerDelegate<NSObject>
 
 @optional
 
-/** Called when the user taps on a cluster marker. */
+/**
+ * Called when the user taps on a cluster marker.
+ */
 - (void)clusterManager:(GMUClusterManager *)clusterManager didTapCluster:(id<GMUCluster>)cluster;
 
-/** Called when the user taps on a cluster item marker. */
-- (void)clusterManager:(GMUClusterManager *)clusterManager
-     didTapClusterItem:(id<GMUClusterItem>)clusterItem;
+/** 
+ * Called when the user taps on a cluster item marker. 
+ */
+- (void)clusterManager:(GMUClusterManager *)clusterManager didTapClusterItem:(id<GMUClusterItem>)clusterItem;
 
 @end
 
@@ -45,15 +50,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GMUClusterManager : NSObject<GMSMapViewDelegate>
 
-/** Disallow default initializer */
-- (id)init __attribute__((unavailable("Use initWithMap:algorithm:renderer: instead.")));
+/**
+ * The default initializer is not available. Use initWithMap:algorithm:renderer instead.
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
-/** Initializer with the |mapView|, |algorithm| and |renderer|. */
-- (instancetype)initWithMap:(GMSMapView *)mapView
-                  algorithm:(id<GMUClusterAlgorithm>)algorithm
-                   renderer:(id<GMUClusterRenderer>)renderer;
+/**
+ * Returns a new instance of the GMUClusterManager class defined by it's |algorithm| and |renderer|.
+ */
+- (instancetype)initWithMap:(GMSMapView *)mapView algorithm:(id<GMUClusterAlgorithm>)algorithm renderer:(id<GMUClusterRenderer>)renderer NS_DESIGNATED_INITIALIZER;
 
-/** Gets the clustering algorithm. */
+/**
+ * Returns the clustering algorithm.
+ */
 @property(nonatomic, readonly) id<GMUClusterAlgorithm> algorithm;
 
 /**
@@ -82,19 +91,26 @@ NS_ASSUME_NONNULL_BEGIN
  * In this example self will receive type-safe GMUClusterManagerDelegate
  * events and other map events will be forwarded to the current map delegate.
  */
-- (void)setDelegate:(id<GMUClusterManagerDelegate> _Nullable)delegate
-        mapDelegate:(id<GMSMapViewDelegate> _Nullable)mapDelegate;
+- (void)setDelegate:(id<GMUClusterManagerDelegate> _Nullable)delegate mapDelegate:(id<GMSMapViewDelegate> _Nullable)mapDelegate;
 
-/** Adds a cluster item to the collection. */
+/**
+ * Adds a cluster item to the collection. 
+ */
 - (void)addItem:(id<GMUClusterItem>)item;
 
-/** Adds multiple cluster items to the collection. */
+/** 
+ * Adds multiple cluster items to the collection. 
+ */
 - (void)addItems:(NSArray<id<GMUClusterItem>> *)items;
 
-/** Removes a cluster item from the collection. */
+/** 
+ * Removes a cluster item from the collection. 
+ */
 - (void)removeItem:(id<GMUClusterItem>)item;
 
-/** Removes all items from the collection. */
+/** 
+ * Removes all items from the collection. 
+ */
 - (void)clearItems;
 
 /**

--- a/src/Clustering/GMUClusterManager.h
+++ b/src/Clustering/GMUClusterManager.h
@@ -58,7 +58,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a new instance of the GMUClusterManager class defined by it's |algorithm| and |renderer|.
  */
-- (instancetype)initWithMap:(GMSMapView *)mapView algorithm:(id<GMUClusterAlgorithm>)algorithm renderer:(id<GMUClusterRenderer>)renderer NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMap:(GMSMapView *)mapView
+                  algorithm:(id<GMUClusterAlgorithm>)algorithm
+                   renderer:(id<GMUClusterRenderer>)renderer NS_DESIGNATED_INITIALIZER;
 
 /**
  * Returns the clustering algorithm.
@@ -91,7 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
  * In this example self will receive type-safe GMUClusterManagerDelegate
  * events and other map events will be forwarded to the current map delegate.
  */
-- (void)setDelegate:(id<GMUClusterManagerDelegate> _Nullable)delegate mapDelegate:(id<GMSMapViewDelegate> _Nullable)mapDelegate;
+- (void)setDelegate:(id<GMUClusterManagerDelegate> _Nullable)delegate
+        mapDelegate:(id<GMSMapViewDelegate> _Nullable)mapDelegate;
 
 /**
  * Adds a cluster item to the collection. 

--- a/src/Clustering/GMUClusterManager.m
+++ b/src/Clustering/GMUClusterManager.m
@@ -50,16 +50,6 @@ static const double kGMUClusterWaitIntervalSeconds = 0.2;
   id<GMUClusterRenderer> _renderer;
 }
 
-// Disables init.
-- (instancetype)init {
-  self = [self initWithNullableMap:nil algorithm:nil renderer:nil];
-  if (self) {
-    [self doesNotRecognizeSelector:_cmd];
-    self = nil;
-  }
-  return self;
-}
-
 - (instancetype)initWithMap:(GMSMapView *)mapView
                   algorithm:(id<GMUClusterAlgorithm>)algorithm
                    renderer:(id<GMUClusterRenderer>)renderer {

--- a/src/Clustering/GMUClusterManager.m
+++ b/src/Clustering/GMUClusterManager.m
@@ -28,14 +28,6 @@ static NSString *const kGMUCameraKeyPath = @"camera";
 // to avoid continuous clustering when the camera is moving which can affect performance.
 static const double kGMUClusterWaitIntervalSeconds = 0.2;
 
-@interface GMUClusterManager ()
-
-- (instancetype)initWithNullableMap:(GMSMapView *)mapView
-                          algorithm:(id<GMUClusterAlgorithm>)algorithm
-                           renderer:(id<GMUClusterRenderer>)renderer NS_DESIGNATED_INITIALIZER;
-
-@end
-
 @implementation GMUClusterManager {
   // The map view that this object is associated with.
   __weak GMSMapView *_mapView;
@@ -53,23 +45,20 @@ static const double kGMUClusterWaitIntervalSeconds = 0.2;
 - (instancetype)initWithMap:(GMSMapView *)mapView
                   algorithm:(id<GMUClusterAlgorithm>)algorithm
                    renderer:(id<GMUClusterRenderer>)renderer {
-  return [self initWithNullableMap:mapView algorithm:algorithm renderer:renderer];
-}
 
-- (instancetype)initWithNullableMap:(GMSMapView *)mapView
-                          algorithm:(id<GMUClusterAlgorithm>)algorithm
-                           renderer:(id<GMUClusterRenderer>)renderer {
   if ((self = [super init])) {
     _algorithm = [[GMUSimpleClusterAlgorithm alloc] init];
     _mapView = mapView;
     _previousCamera = _mapView.camera;
     _algorithm = algorithm;
     _renderer = renderer;
+
     [_mapView addObserver:self
                forKeyPath:kGMUCameraKeyPath
                   options:NSKeyValueObservingOptionNew
                   context:nil];
   }
+    
   return self;
 }
 

--- a/src/Clustering/GMUMarkerClustering.h
+++ b/src/Clustering/GMUMarkerClustering.h
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-/** Umbrella header. */
-
 #import <Google-Maps-iOS-Utils/GMUCluster.h>
 #import <Google-Maps-iOS-Utils/GMUClusterItem.h>
 #import <Google-Maps-iOS-Utils/GMUClusterManager.h>

--- a/src/Clustering/GMUStaticCluster.h
+++ b/src/Clustering/GMUStaticCluster.h
@@ -24,7 +24,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GMUStaticCluster : NSObject<GMUCluster>
 
-- (instancetype)initWithPosition:(CLLocationCoordinate2D)position;
+/**
+ * The default initializer is not available. Use initWithPosition: instead.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Returns a new instance of the GMUStaticCluster class defined by it's position.
+ */
+- (instancetype)initWithPosition:(CLLocationCoordinate2D)position NS_DESIGNATED_INITIALIZER;
 
 /**
  * Returns the position of the cluster.

--- a/src/Clustering/GMUStaticCluster.m
+++ b/src/Clustering/GMUStaticCluster.m
@@ -23,16 +23,6 @@
   NSMutableArray<id<GMUClusterItem>> *_items;
 }
 
-// Disables init.
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    [self doesNotRecognizeSelector:_cmd];
-    self = nil;
-  }
-  return self;
-}
-
 - (instancetype)initWithPosition:(CLLocationCoordinate2D)position {
   if ((self = [super init])) {
     _items = [[NSMutableArray alloc] init];


### PR DESCRIPTION
Hey guys,

first of all, great utility library, love it! I use it to support clustering with Titanium and it works as expected. While fixing some recent Analyser warnings in my project, I noticed that the library also had one (trivial) warning. We use the following to disable the default initializer:
```objc
- (instancetype)init {
  self = [self initWithNullableMap:nil algorithm:nil renderer:nil];
  if (self) {
    [self doesNotRecognizeSelector:_cmd];
    self = nil;
  }
  return self;
}
```
The `initWithNullableMap:algorithm:renderer` method then assigns `nil` values to the properties and throws the `Unrecognized Selector` system error. But the `algorithm` property is non-null in the interface, so it throws the warning. Simple as that. The other ones are already `nullable`, so they pass the Analyser. With this PR, the behavior is normalized, so all cluster manager properties have the same nullability. 

An alternate solution would be to solve the disallowed `init` initializer by using the following:

```objc
- (id)init {
    [self release];
    @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                   reason:@"The default initializer is not allowed. Please use initWithMap:algorithm:renderer instead!"
                                 userInfo:nil];
    return nil;
}
```

Let me know what you prefer. Thx and happy new year!