### PR TITLE
Bugfix: even shouldRenderAsCluster returns false,  the items in visib…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 .idea/
 Pods/
 Podfile.lock
+GMUMarkerClustering.h

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -226,11 +226,11 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     float zoom = _mapView.camera.zoom;
     
     for (id<GMUCluster> cluster in clusters) {
-        if ([_renderedClusters containsObject:cluster]) {
-            continue;
-        }
-        
         if ([self shouldRenderAsCluster:cluster atZoom:zoom]) {
+            if ([_renderedClusters containsObject:cluster]) {
+                continue;
+            }
+            
             if (![visibleBounds containsCoordinate:cluster.position]) {
                 continue;
             }


### PR DESCRIPTION
Because what cluster's position is in visible map bounds is cheked before it checks `shouldRenderAsCluster`, it removes markers in visible map bounds which of cluster is not in visible map bounds.