### PR TITLE
Bug fix (#104) - GMUStaticCluster missing from library header

### DIFF
--- a/src/Clustering/GMUMarkerClustering.h
+++ b/src/Clustering/GMUMarkerClustering.h
@@ -20,5 +20,6 @@
 #import <Google-Maps-iOS-Utils/GMUDefaultClusterRenderer.h>
 #import <Google-Maps-iOS-Utils/GMUGridBasedClusterAlgorithm.h>
 #import <Google-Maps-iOS-Utils/GMUNonHierarchicalDistanceBasedAlgorithm.h>
+#import <Google-Maps-iOS-Utils/GMUStaticCluster.h>
 
 #import "Google-Maps-iOS-Utils/GQTPointQuadTree.h"


### PR DESCRIPTION
Bug #104 - Fixed missing header entry for GMUStaticCluster protocol, enabling access by callers.