### PR TITLE
Mark renderer:markerForObject: as nullable

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.h
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Note that changing a marker's position is not recommended because it will
  * interfere with the marker animation.
  */
-- (GMSMarker *)renderer:(id<GMUClusterRenderer>)renderer markerForObject:(id)object;
+- (nullable GMSMarker *)renderer:(id<GMUClusterRenderer>)renderer markerForObject:(id)object;
 
 /**
  * Raised when a marker (for a cluster or an item) is about to be added to the map.


### PR DESCRIPTION
This changes the return value to be an optional for swift, and allows
to use the default marker if returning nil from the swift delegate.