### PR TITLE
Implement mapView:didTapPOIWithPlaceID:name:location:

### DIFF
--- a/src/Clustering/GMUClusterManager.m
+++ b/src/Clustering/GMUClusterManager.m
@@ -181,6 +181,12 @@ static const double kGMUClusterWaitIntervalSeconds = 0.2;
   return nil;
 }
 
+- (void)mapView:(GMSMapView *)mapView didTapPOIWithPlaceID:(NSString *)placeID name:(NSString *)name location:(CLLocationCoordinate2D)location {
+    if ([_mapDelegate respondsToSelector:@selector(mapView:didTapPOIWithPlaceID:name:location:)]) {
+        [_mapDelegate mapView:mapView didTapPOIWithPlaceID:placeID name:name location:location];
+    }
+}
+
 - (UIView *)mapView:(GMSMapView *)mapView markerInfoContents:(GMSMarker *)marker {
   if ([_mapDelegate respondsToSelector:@selector(mapView:markerInfoContents:)]) {
     return [_mapDelegate mapView:mapView markerInfoContents:marker];


### PR DESCRIPTION
The method mapView:didTapPOIWithPlaceID:name:location: was missing, so
any app using a cluster manager was not able to react to taps on points
of interest.