### PR TITLE
If cluster is expanded and an item is visible, show cluster

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -229,13 +229,22 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     if ([_renderedClusters containsObject:cluster]) continue;
 
     BOOL shouldShowCluster = [visibleBounds containsCoordinate:cluster.position];
-    if (!shouldShowCluster && animated) {
+    BOOL shouldRenderAsCluster [self shouldRenderAsCluster:cluster atZoom: _mapView.camera.zoom];
+
+    if (!shouldShowCluster) {
       for (id<GMUClusterItem> item in cluster.items) {
-        GMUWrappingDictionaryKey *key = [[GMUWrappingDictionaryKey alloc] initWithObject:item];
-        id<GMUCluster> oldCluster = [_itemToOldClusterMap objectForKey:key];
-        if (oldCluster != nil && [visibleBounds containsCoordinate:oldCluster.position]) {
+        BOOL itemIsVisible = [visibleBounds containsCoordinate:item.position];
+        if (!shouldRenderAsCluster && itemIsVisible) {
           shouldShowCluster = YES;
           break;
+        }
+        if (animated) {
+          GMUWrappingDictionaryKey *key = [[GMUWrappingDictionaryKey alloc] initWithObject:item];
+          id<GMUCluster> oldCluster = [_itemToOldClusterMap objectForKey:key];
+          if (oldCluster != nil && itemIsVisible) {
+            shouldShowCluster = YES;
+            break;
+          }
         }
       }
     }

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -241,7 +241,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
         if (animated) {
           GMUWrappingDictionaryKey *key = [[GMUWrappingDictionaryKey alloc] initWithObject:item];
           id<GMUCluster> oldCluster = [_itemToOldClusterMap objectForKey:key];
-          if (oldCluster != nil && itemIsVisible) {
+          if (oldCluster != nil && [visibleBounds containsCoordinate:oldCluster.position]) {
             shouldShowCluster = YES;
             break;
           }

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -229,7 +229,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     if ([_renderedClusters containsObject:cluster]) continue;
 
     BOOL shouldShowCluster = [visibleBounds containsCoordinate:cluster.position];
-    BOOL shouldRenderAsCluster [self shouldRenderAsCluster:cluster atZoom: _mapView.camera.zoom];
+    BOOL shouldRenderAsCluster = [self shouldRenderAsCluster:cluster atZoom: _mapView.camera.zoom];
 
     if (!shouldShowCluster) {
       for (id<GMUClusterItem> item in cluster.items) {

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -233,8 +233,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
     if (!shouldShowCluster) {
       for (id<GMUClusterItem> item in cluster.items) {
-        BOOL itemIsVisible = [visibleBounds containsCoordinate:item.position];
-        if (!shouldRenderAsCluster && itemIsVisible) {
+        if (!shouldRenderAsCluster && [visibleBounds containsCoordinate:item.position]) {
           shouldShowCluster = YES;
           break;
         }


### PR DESCRIPTION
This is a fix for issue #150 problem with animatesClusters. If a cluster was partially on the screen, the cluster's representative cluster item was off the screen, and the cluster was not to be rendered as a cluster, then the cluster would not be shown. Usually what I'd see is I'd change the zoom level and suddenly a cluster item (usually near the side of the screen) would disappear.

The fix is: when iterating through a cluster's items, if the cluster is not to be rendered as a cluster and if at least one cluster item is visible, then show the cluster. Otherwise the cluster item(s) will disppear from the screen.

As in @theolof's write up of the issue, setting animateClusters to `true` prevents this behavior because it forces each cluster to always be rendered.