### PR TITLE
Fix no animation when kGMSMaxClusterZoom is reached

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -105,9 +105,10 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 - (void)renderAnimatedClusters:(NSArray<id<GMUCluster>> *)clusters {
   float zoom = _mapView.camera.zoom;
   BOOL isZoomingIn = zoom > _previousZoom;
-  _previousZoom = zoom;
 
   [self prepareClustersForAnimation:clusters isZoomingIn:isZoomingIn];
+    
+  _previousZoom = zoom;
 
   _clusters = [clusters copy];
 
@@ -195,7 +196,10 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     _itemToOldClusterMap =
         [[NSMutableDictionary<GMUWrappingDictionaryKey *, id<GMUCluster>> alloc] init];
     for (id<GMUCluster> cluster in _clusters) {
-      if (![self shouldRenderAsCluster:cluster atZoom:zoom]) continue;
+      if (![self shouldRenderAsCluster:cluster atZoom:zoom]
+          && ![self shouldRenderAsCluster:cluster atZoom:_previousZoom]) {
+          continue;
+      }
       for (id<GMUClusterItem> clusterItem in cluster.items) {
         GMUWrappingDictionaryKey *key =
             [[GMUWrappingDictionaryKey alloc] initWithObject:clusterItem];

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -198,7 +198,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     for (id<GMUCluster> cluster in _clusters) {
       if (![self shouldRenderAsCluster:cluster atZoom:zoom]
           && ![self shouldRenderAsCluster:cluster atZoom:_previousZoom]) {
-          continue;
+        continue;
       }
       for (id<GMUClusterItem> clusterItem in cluster.items) {
         GMUWrappingDictionaryKey *key =

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -107,7 +107,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
   BOOL isZoomingIn = zoom > _previousZoom;
 
   [self prepareClustersForAnimation:clusters isZoomingIn:isZoomingIn];
-    
+
   _previousZoom = zoom;
 
   _clusters = [clusters copy];


### PR DESCRIPTION
Fix for issue #131 missing animation when kGMSMaxClusterSize is reached. Currently, when zooming in, if a cluster is not to be rendered as a cluster at the target zoom level then the cluster item animation is skipped. This is done irrespective of the previous zoom level. So if you double tap to zoom from level 12.5 to 13.5, and you have kGMSMaxClusterSize set at 13, then any visible clusters will dissolve without animation.

The fix I've implemented delays setting _previousZoom until after prepareClustersForAnimation:isZoomingIn: completes. And then to use _previousZoom in that method to detect whether a cluster is dissolving when zooming in in order to animate the placement of its cluster items.