### PR TITLE
Fix typo in Heatmap/GMUGradient.h import of UIKit header

### DIFF
--- a/src/Heatmap/GMUGradient.h
+++ b/src/Heatmap/GMUGradient.h
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#import <UIKit/UIKIt.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Typo in import (UIKIt instead of UIKit) led to failure when building on case sensitive file system