### PR TITLE
Adds support for StyleMap

### DIFF
--- a/src/Geometry/GMUGeometryRenderer.h
+++ b/src/Geometry/GMUGeometryRenderer.h
@@ -19,6 +19,7 @@
 
 #import "GMUGeometryContainer.h"
 #import "GMUStyle.h"
+#import "GMUStyleMap.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -47,6 +48,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMap:(GMSMapView *)map
                  geometries:(NSArray<id<GMUGeometryContainer>> *)geometries
                      styles:(NSArray<GMUStyle *> *_Nullable)styles;
+/**
+ * Initializes a new renderer.
+ *
+ * @param map the Google Map layer to render the geometries onto.
+ * @param geometries the geometries to be rendered.
+ * @param styles the styles to be applied to the geometries.
+ * @param styleMaps the styleMaps to be applied to the geometries
+ */
+- (instancetype)initWithMap:(GMSMapView *)map
+                 geometries:(NSArray<id<GMUGeometryContainer>> *)geometries
+                     styles:(NSArray<GMUStyle *> * _Nullable)styles
+                  styleMaps:(NSArray<GMUStyleMap *> *_Nullable)styleMaps;
 /**
  * Renders the geometries onto the Google Map.
  */

--- a/src/Geometry/GMUGeometryRenderer.m
+++ b/src/Geometry/GMUGeometryRenderer.m
@@ -24,6 +24,8 @@
 #import "GMUPolygon.h"
 #import "GMUStyle.h"
 
+static NSString *const kStyleMapDefaultState = @"normal";
+
 @implementation GMUGeometryRenderer {
   NSMutableArray<GMSOverlay *> *_mapOverlays;
 
@@ -41,6 +43,11 @@
    * The list of parsed styles to be applied to the placemarks.
    */
   NSDictionary<NSString *, GMUStyle *> *_styles;
+
+  /**
+   * The list of parsed style maps to be applied to the placemarks.
+   */
+  NSDictionary<NSString *, GMUStyleMap *> *_styleMaps;
 
   /**
    * The dispatch queue used to download images for ground overlays and point icons.
@@ -61,10 +68,18 @@
 - (instancetype)initWithMap:(GMSMapView *)map
                  geometries:(NSArray<id<GMUGeometryContainer>> *)geometries
                      styles:(NSArray<GMUStyle *> *)styles {
+    return [self initWithMap:map geometries:geometries styles:nil styleMaps:nil];
+}
+
+- (instancetype)initWithMap:(GMSMapView *)map
+                 geometries:(NSArray<id<GMUGeometryContainer>> *)geometries
+                     styles:(NSArray<GMUStyle *> *)styles
+                  styleMaps:(NSArray<GMUStyleMap *> *)styleMaps {
   if (self = [super init]) {
     _map = map;
     _geometryContainers = geometries;
     _styles = [[self class] stylesDictionaryFromArray:styles];
+    _styleMaps = [[self class] styleMapsDictionaryFromArray: styleMaps];
     _mapOverlays = [[NSMutableArray alloc] init];
     _queue = dispatch_queue_create("com.google.gmsutils", DISPATCH_QUEUE_CONCURRENT);
   }
@@ -96,6 +111,14 @@
   return dict;
 }
 
++ (NSDictionary<NSString *, GMUStyleMap *> *)styleMapsDictionaryFromArray:(NSArray<GMUStyleMap *> *)styleMaps {
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:styleMaps.count];
+    for (GMUStyleMap *styleMap in styleMaps) {
+        [dict setObject:styleMap forKey:styleMap.styleMapId];
+    }
+    return dict;
+}
+
 + (UIImage *)imageFromPath:(NSString *)path {
   // URLWithString returns nil for a path formatted as a local file reference.
   NSURL *url = [NSURL URLWithString:path];
@@ -111,12 +134,26 @@
   return [UIImage imageWithData:data];
 }
 
+- (GMUStyle *)getStyleFromStyleMaps:(NSString *)styleUrl {
+    GMUStyleMap *styleMap = [_styleMaps objectForKey:styleUrl];
+    if (styleMap) {
+        for (GMUPair *pair in styleMap.pairs) {
+            if ([pair.key isEqual:kStyleMapDefaultState]) {
+                return [_styles objectForKey:pair.styleUrl];
+            }
+        }
+    }
+    return nil;
+}
+
 - (void)renderGeometryContainers:(NSArray<id<GMUGeometryContainer>> *)containers {
   for (id<GMUGeometryContainer> container in containers) {
     GMUStyle *style = container.style;
     if (!style && [container isKindOfClass:[GMUPlacemark class]]) {
       GMUPlacemark *placemark = container;
       style = [_styles objectForKey:placemark.styleUrl];
+      // If not found, look it up in one of the StyleMaps
+      style = style ?: [self getStyleFromStyleMaps:placemark.styleUrl];
     }
     [self renderGeometryContainer:container style:style];
   }

--- a/src/Geometry/GMUKMLParser.h
+++ b/src/Geometry/GMUKMLParser.h
@@ -18,6 +18,8 @@
 
 #import <GoogleMaps/GoogleMaps.h>
 
+#import "GMUStyleMap.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class GMUStyle;
@@ -39,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
  * The styles parsed from the KML file.
  */
 @property(nonatomic, readonly) NSArray<GMUStyle *> *styles;
+
+@property(nonatomic, readonly) NSArray<GMUStyleMap *> *styleMaps;
 
 /**
  * Parses the stored KML document.

--- a/src/Geometry/Model/GMUPair.h
+++ b/src/Geometry/Model/GMUPair.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Instances of this class represent a geometry Style. It is used to define the
+ * stylings of any number of GMUGeometry objects.
+ */
+@interface GMUPair : NSObject
+
+@property(nonatomic, readonly) NSString *key;
+@property(nonatomic, readonly) NSString *styleUrl;
+
+- (instancetype)initWithKey:(NSString *)styleID
+                   styleUrl:(NSString *)strokeColor;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/src/Geometry/Model/GMUPair.m
+++ b/src/Geometry/Model/GMUPair.m
@@ -1,0 +1,32 @@
+/* Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GMUPair.h"
+
+@implementation GMUPair
+
+@synthesize key = _key;
+@synthesize styleUrl = _styleUrl;
+
+- (instancetype)initWithKey:(NSString *)key
+                   styleUrl:(NSString *)styleUrl {
+    if (self = [super init]) {
+        _key = key;
+        _styleUrl = styleUrl;
+    }
+    return self;
+}
+
+@end

--- a/src/Geometry/Model/GMUStyleMap.h
+++ b/src/Geometry/Model/GMUStyleMap.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GMUPair.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GMUStyleMap : NSObject
+
+@property(nonatomic, readonly) NSString *styleMapId;
+@property(nonatomic, readonly) NSArray<GMUPair *> *pairs;
+
+- (instancetype)initWithId:(NSString *)styleMapId
+                   pairs:(NSArray<GMUPair *> *)pairs;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/Geometry/Model/GMUStyleMap.m
+++ b/src/Geometry/Model/GMUStyleMap.m
@@ -1,0 +1,33 @@
+/* Copyright (c) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GMUPair.h"
+#import "GMUStyleMap.h"
+
+@implementation GMUStyleMap
+
+@synthesize styleMapId = _id;
+@synthesize pairs = _pairs;
+
+- (instancetype)initWithId:(NSString *)styleMapId
+                     pairs:(NSArray<GMUPair *> *)pairs {
+    if (self = [super init]) {
+        _id = styleMapId;
+        _pairs = pairs;
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
https://developers.google.com/kml/documentation/kmlreference#stylemap
I am using this lib on both Android and iOS versions of my app.
The KML file that I am using contains StyleMap tags. On Android it renders well, but on iOS the Placemarks have no colors.

I've noticed that the KML Parser in the iOS lib has support for fewer tags than the one for Android, so I had to add this one myself. Maybe this will be useful for others as well..