### PR TITLE
Fixes #209: GMUGeometryRenderer is not applying the external styles when no styleMaps are specified

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -15,3 +15,4 @@ Michael Lapuebla <chainedtothewoods@gmail.com>
 Daniel Kostrzynski <kostrzynski@google.com>
 Christian Ihle <blurpy@gmail.com>
 Gareth Pearce <garethpearce@google.com>
+Xurxo Mendez <sonxurxo@gmail.com>

--- a/src/Geometry/GMUGeometryRenderer.m
+++ b/src/Geometry/GMUGeometryRenderer.m
@@ -68,7 +68,7 @@ static NSString *const kStyleMapDefaultState = @"normal";
 - (instancetype)initWithMap:(GMSMapView *)map
                  geometries:(NSArray<id<GMUGeometryContainer>> *)geometries
                      styles:(NSArray<GMUStyle *> *)styles {
-    return [self initWithMap:map geometries:geometries styles:nil styleMaps:nil];
+    return [self initWithMap:map geometries:geometries styles:styles styleMaps:nil];
 }
 
 - (instancetype)initWithMap:(GMSMapView *)map


### PR DESCRIPTION
Fixes #209: GMUGeometryRenderer is not applying the external styles when no styleMaps are specified

- [x] Test passing
- [x] CLA submitted