### PR TITLE
feat: expose private cluster configuration to public API, resolve Xcode 10 warnings

### DIFF
--- a/app/BasicViewController.m
+++ b/app/BasicViewController.m
@@ -62,6 +62,12 @@ typedef NS_ENUM(NSInteger, ClusterAlgorithmMode) {
       [[GMUDefaultClusterRenderer alloc] initWithMapView:_mapView
                                     clusterIconGenerator:iconGenerator];
   renderer.delegate = self;
+
+  // The following properties can be used to fine-tune the cluster rendering (using defaults):
+  renderer.animationDuration = 0.5;
+  renderer.minimumClusterSize = 4;
+  renderer.maximumClusterZoom = 20;
+
   _clusterManager =
       [[GMUClusterManager alloc] initWithMap:_mapView algorithm:algorithm renderer:renderer];
 

--- a/src/Clustering/View/GMUDefaultClusterRenderer.h
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.h
@@ -72,6 +72,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GMUDefaultClusterRenderer : NSObject<GMUClusterRenderer>
 
 /**
+ * Creates a new cluster renderer with a given map view and icon generator.
+ *
+ * @param mapView The map view to use.
+ * @param icongeneration The icon generator to use. Can be subclassed if required.
+ */
+- (instancetype)initWithMapView:(GMSMapView *)mapView
+           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;
+
+/**
  * Animates the clusters to achieve splitting (when zooming in) and merging
  * (when zooming out) effects:
  * - splitting large clusters into smaller ones when zooming in.
@@ -93,9 +102,35 @@ NS_ASSUME_NONNULL_BEGIN
  * split into 3 clusters of size 3, 4, 5. For hierarchical clusters, the numbers
  * should add up however.
  *
- * Default to YES.
+ * Defaults to YES.
  */
 @property(nonatomic) BOOL animatesClusters;
+
+/**
+ * Determines the minimum number of cluster items inside a cluster.
+ * Clusters smaller than this threshold will be expanded.
+ *
+ * Defaults to 4.
+ */
+@property(nonatomic) NSUInteger minimumClusterSize;
+
+/**
+ * Sets the maximium zoom level of the map on which the clustering
+ * should be applied. At zooms above this level, clusters will be expanded.
+ * This is to prevent cases where items are so close to each other than they
+ * are always grouped.
+ *
+ * Defaults to 20.
+ */
+@property(nonatomic) NSUInteger maximumClusterZoom;
+
+/**
+ * Sets the animation duration for marker splitting/merging effects.
+ * Measured in seconds.
+ *
+ * Defaults to 0.5.
+ */
+@property(nonatomic) double animationDuration;
 
 /**
  * Allows setting a zIndex value for the clusters.  This becomes useful
@@ -110,9 +145,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Sets to further customize the renderer. */
 @property(nonatomic, nullable, weak) id<GMUClusterRendererDelegate> delegate;
-
-- (instancetype)initWithMapView:(GMSMapView *)mapView
-           clusterIconGenerator:(id<GMUClusterIconGenerator>)iconGenerator;
 
 /**
  * If returns NO, cluster items will be expanded and rendered as normal markers.

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -72,6 +72,10 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
     _renderedClusters = [[NSMutableSet alloc] init];
     _renderedClusterItems = [[NSMutableSet alloc] init];
     _animatesClusters = YES;
+    _minimumClusterSize = kGMUMinClusterSize;
+    _maximumClusterZoom = kGMUMaxClusterZoom;
+    _animationDuration = kGMUAnimationDuration;
+
     _zIndex = 1;
   }
   return self;
@@ -82,7 +86,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 }
 
 - (BOOL)shouldRenderAsCluster:(id<GMUCluster>)cluster atZoom:(float)zoom {
-  return cluster.count >= kGMUMinClusterSize && zoom <= kGMUMaxClusterZoom;
+  return cluster.count >= _minimumClusterSize && zoom <= _maximumClusterZoom;
 }
 
 #pragma mark GMUClusterRenderer
@@ -159,7 +163,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
     // All is good, perform the animation.
     [CATransaction begin];
-    [CATransaction setAnimationDuration:kGMUAnimationDuration];
+    [CATransaction setAnimationDuration:_animationDuration];
     CLLocationCoordinate2D toPosition = toCluster.position;
     marker.layer.latitude = toPosition.latitude;
     marker.layer.longitude = toPosition.longitude;
@@ -167,7 +171,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
   }
 
   // Clears existing markers after animation has presumably ended.
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kGMUAnimationDuration * NSEC_PER_SEC),
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, _animationDuration * NSEC_PER_SEC),
                  dispatch_get_main_queue(), ^{
                    [self clearMarkers:markers];
                  });
@@ -330,7 +334,7 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
   if (animated) {
     [CATransaction begin];
-    [CATransaction setAnimationDuration:kGMUAnimationDuration];
+    [CATransaction setAnimationDuration:_animationDuration];
     marker.layer.latitude = position.latitude;
     marker.layer.longitude = position.longitude;
     [CATransaction commit];

--- a/src/Geometry/GMUGeometryRenderer.m
+++ b/src/Geometry/GMUGeometryRenderer.m
@@ -212,7 +212,7 @@ static NSString *const kStyleMapDefaultState = @"normal";
         GMSMarker *strongMarker = weakMarker;
         GMSMapView *strongMap = weakMap;
         strongMarker.icon = image;
-        if (!_isMapCleared) {
+        if (!self->_isMapCleared) {
           strongMarker.map = strongMap;
         }
       });
@@ -307,7 +307,7 @@ static NSString *const kStyleMapDefaultState = @"normal";
       GMSGroundOverlay *strongGroundOverlay = weakGroundOverlay;
       GMSMapView *strongMap = weakMap;
       strongGroundOverlay.icon = image;
-      if (!_isMapCleared) {
+      if (!self->_isMapCleared) {
         strongGroundOverlay.map = strongMap;
       }
     });

--- a/test/unit/Clustering/GMUClusterAlgorithmTest.h
+++ b/test/unit/Clustering/GMUClusterAlgorithmTest.h
@@ -17,7 +17,7 @@
 
 #import "Clustering/GMUClusterItem.h"
 
-#import "Common/Model/GMUTestClusterItem.h"
+#import "common/Model/GMUTestClusterItem.h"
 
 @protocol GMUCluster;
 

--- a/test/unit/Clustering/GMUClusterManagerTest.m
+++ b/test/unit/Clustering/GMUClusterManagerTest.m
@@ -45,7 +45,7 @@ static const double kCameraZoom = 10.0;
   _mapView = OCMClassMock([GMSMapView class]);
   _camera = [GMSCameraPosition cameraWithTarget:kCameraPosition zoom:kCameraZoom];
   [[[_mapView stub] andDo:^(NSInvocation *invocation) {
-    [invocation setReturnValue:&_camera];
+    [invocation setReturnValue:&self->_camera];
   }] camera];
 
   _algorithm = OCMProtocolMock(@protocol(GMUClusterAlgorithm));

--- a/test/unit/Clustering/GMUDefaultClusterRendererTest.m
+++ b/test/unit/Clustering/GMUDefaultClusterRendererTest.m
@@ -21,7 +21,7 @@
 
 #import "Clustering/GMUStaticCluster.h"
 #import "Clustering/View/GMUClusterIconGenerator.h"
-#import "Common/Model/GMUTestClusterItem.h"
+#import "common/Model/GMUTestClusterItem.h"
 
 #import <GoogleMaps/GoogleMaps.h>
 #import <OCMock/OCMock.h>
@@ -74,22 +74,22 @@ static const CLLocationCoordinate2D kCameraPosition = {-35, 151};
   NSMutableArray<id<GMUCluster>> *clusters = [[NSMutableArray<id<GMUCluster>> alloc] init];
   GMUStaticCluster *cluster1 = [self clusterAroundPosition:kCameraPosition count:10];
   [clusters addObject:cluster1];
-
+  
   GMUStaticCluster *cluster2 =
-      [self clusterAroundPosition:CLLocationCoordinate2DMake(kCameraPosition.latitude + 1.0,
-                                                             kCameraPosition.longitude)
-                            count:4];
+  [self clusterAroundPosition:CLLocationCoordinate2DMake(kCameraPosition.latitude + 1.0,
+                                                         kCameraPosition.longitude)
+                        count:4];
   [clusters addObject:cluster2];
-
+  
   // Act.
   [_renderer renderClusters:clusters];
-
+  
   // Assert.
   NSArray<GMSMarker *> *markers = [_renderer markers];
   XCTAssertEqual(markers.count, 2);
   XCTAssertTrue([markers[0].userData conformsToProtocol:@protocol(GMUCluster)]);
   XCTAssertEqual(markers[0].map, _mapView);
-
+  
   XCTAssertTrue([markers[1].userData conformsToProtocol:@protocol(GMUCluster)]);
   XCTAssertEqual(markers[1].map, _mapView);
 }

--- a/test/unit/Geometry/GMUGeometryRendererTest.m
+++ b/test/unit/Geometry/GMUGeometryRendererTest.m
@@ -189,7 +189,7 @@ static NSString *const kStyleId = @"#style";
   CLLocationCoordinate2D position = CLLocationCoordinate2DMake(45.123, 90.456);
   GMUPoint *point = [[GMUPoint alloc] initWithCoordinate:position];
   GMUPlacemark *placemark = [[GMUPlacemark alloc] initWithGeometry:point
-                                                             title:nil
+                                                             title:kTitleText
                                                            snippet:nil
                                                              style:nil
                                                           styleUrl:kStyleId];

--- a/workspace/GoogleMapsUtils.xcodeproj/project.pbxproj
+++ b/workspace/GoogleMapsUtils.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0229C0F91D9A461000551202 /* GMU-DevApp.release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0229C0F71D9A461000551202 /* GMU-DevApp.release.xcconfig */; };
-		0229C0FA1D9A461000551202 /* GMU-DevApp.debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0229C0F81D9A461000551202 /* GMU-DevApp.debug.xcconfig */; };
 		0229C0FD1D9B4C0800551202 /* CustomMarkerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0229C0FC1D9B4C0800551202 /* CustomMarkerViewController.m */; };
 		0233207D1CACF991008024F2 /* GMUNonHierarchicalDistanceBasedAlgorithm.m in Sources */ = {isa = PBXBuildFile; fileRef = 0233207C1CACF991008024F2 /* GMUNonHierarchicalDistanceBasedAlgorithm.m */; };
 		023320831CB20086008024F2 /* GMUWrappingDictionaryKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 023320821CB20086008024F2 /* GMUWrappingDictionaryKey.m */; };
@@ -32,7 +30,6 @@
 		02847D0C1CF5239900508850 /* GMUClusterManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 02847D0B1CF5239900508850 /* GMUClusterManagerTest.m */; };
 		028A1BBE1D9A3B1900C4A4FF /* Samples.m in Sources */ = {isa = PBXBuildFile; fileRef = 028A1BBD1D9A3B1900C4A4FF /* Samples.m */; };
 		029EAC301D9A353D00797AE7 /* MasterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 029EAC2F1D9A353D00797AE7 /* MasterViewController.m */; };
-		02BB27601D741A5300DE1EF0 /* GMU-Target.common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 02BB275F1D741A5300DE1EF0 /* GMU-Target.common.xcconfig */; };
 		02DEA4C61CFBC0B900ACF7D8 /* GQTPointQuadTreeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA4C51CFBC0B900ACF7D8 /* GQTPointQuadTreeTest.m */; };
 		02DEA4C81CFC0DDF00ACF7D8 /* GMUDefaultClusterIconGeneratorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA4C71CFC0DDF00ACF7D8 /* GMUDefaultClusterIconGeneratorTest.m */; };
 		02F87BF91D20B61000C65016 /* BasicViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 02F87BE01D20B53B00C65016 /* BasicViewController.m */; };
@@ -788,7 +785,7 @@
 		0242D1721C7C16A400557130 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = Google;
 				TargetAttributes = {
 					0242D1791C7C16A400557130 = {
@@ -833,12 +830,9 @@
 				02F87BFE1D20B64100C65016 /* m2.png in Resources */,
 				02F87BFD1D20B63D00C65016 /* m1.png in Resources */,
 				02F87C071D20B68F00C65016 /* LaunchScreen.storyboard in Resources */,
-				0229C0FA1D9A461000551202 /* GMU-DevApp.debug.xcconfig in Resources */,
-				02BB27601D741A5300DE1EF0 /* GMU-Target.common.xcconfig in Resources */,
 				02F87C001D20B64100C65016 /* m4.png in Resources */,
 				02F87BFF1D20B64100C65016 /* m3.png in Resources */,
 				3491C84F1E5D2DB200A2FA04 /* GeoJSON_Sample.geojson in Resources */,
-				0229C0F91D9A461000551202 /* GMU-DevApp.release.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1064,13 +1058,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1106,13 +1110,23 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1138,6 +1152,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0229C0F81D9A461000551202 /* GMU-DevApp.debug.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1148,6 +1163,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0229C0F71D9A461000551202 /* GMU-DevApp.release.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1158,7 +1174,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0229C0F81D9A461000551202 /* GMU-DevApp.debug.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/../app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1172,7 +1187,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0229C0F71D9A461000551202 /* GMU-DevApp.release.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/../app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1224,6 +1238,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0242D1871C7C18CA00557130 /* GMU-UnitTest.debug.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1238,6 +1253,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0242D20F1C7E72C500557130 /* GMU-UnitTest.release.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Hey there,

this pull refactors a few Xcode 10 warnings as well as exposes the (currently private) renderer configuration properties that help the developer to fine-tune the cluster experience based on the use case. Finally, this pull fixes one unit tests and three unit test warnings. All tests still pass with this change and the change is 100 % backward compatible.