### PR TITLE
Maintain strong reference to GMSMapView in GMSClusterManager

### DIFF
--- a/src/Clustering/GMUClusterManager.m
+++ b/src/Clustering/GMUClusterManager.m
@@ -26,7 +26,7 @@ static const double kGMUClusterWaitIntervalSeconds = 0.2;
 
 @implementation GMUClusterManager {
   // The map view that this object is associated with.
-  __weak GMSMapView *_mapView;
+  GMSMapView *_mapView;
 
   // Position of the camera on the previous cluster invocation.
   GMSCameraPosition *_previousCamera;


### PR DESCRIPTION
This PR fixes https://github.com/googlemaps/google-maps-ios-utils/issues/215.  The `GMSClusterManager` class previously only maintained a weak reference to its `GMSMapView` instance variable.  This could cause potential crashes if the `GMSMapView` object ever deallocated before the `removeObserver:forKeyPath:` method could be called from `dealloc`.

Per [Apple documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOBasics.html), strong references should be maintained for objects observed via KVO:

> Note: The key-value observing addObserver:forKeyPath:options:context: method does not maintain strong references to the observing object, the observed objects, or the context. You should ensure that you maintain strong references to the observing, and observed, objects, and the context as necessary.
 
Because the `GMSClusterManager` class can only be used with a single `GMSMapView` instance, there shouldn't be a reason for the cluster manager to exist without its associated map view (which also justifies the use of a strong reference). 
