### PR TITLE
Fix problem with parse pair element ("key") and make mapOverlays function public

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -15,3 +15,4 @@ Michael Lapuebla <chainedtothewoods@gmail.com>
 Daniel Kostrzynski <kostrzynski@google.com>
 Christian Ihle <blurpy@gmail.com>
 Gareth Pearce <garethpearce@google.com>
+Artem Boboshko <boboshkoa@meta.ua>

--- a/src/Geometry/GMUGeometryRenderer.h
+++ b/src/Geometry/GMUGeometryRenderer.h
@@ -31,6 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GMUGeometryRenderer : NSObject
 
 /**
+ * The overlays array returned from the GMUGeometryRenderer, use after render function.
+ */
+- (NSArray<GMSOverlay *> *)mapOverlays;
+/**
  * Initializes a new renderer.
  *
  * @param map the Google Map layer to render the geometries onto.

--- a/src/Geometry/GMUKMLParser.m
+++ b/src/Geometry/GMUKMLParser.m
@@ -655,7 +655,10 @@ typedef NS_OPTIONS(NSUInteger, GMUParserState) {
                                                    range:NSMakeRange(0, elementName.length)] ||
              [_compassRegex firstMatchInString:elementName
                                        options:0
-                                         range:NSMakeRange(0, elementName.length)]) {
+                                         range:NSMakeRange(0, elementName.length)] ||
+             [_pairAttributeRegex firstMatchInString:elementName
+                                            options:0
+                                       range:NSMakeRange(0, elementName.length)]) {
     [self parseBeginLeafNode];
   }
 }
@@ -672,6 +675,12 @@ typedef NS_OPTIONS(NSUInteger, GMUParserState) {
                                               options:0
                                                 range:NSMakeRange(0, elementName.length)]) {
     [self parseEndStyleAttribute:elementName];
+  } else if ([elementName isEqual:kGMUPairElementName]) {
+      [self parseEndPair];
+  } else if ([_pairAttributeRegex firstMatchInString:elementName
+                                     options:0
+                                       range:NSMakeRange(0, elementName.length)]) {
+      [self parseEndPairAttribute:elementName];
   } else if ([elementName isEqual:kGMUPlacemarkElementName]) {
     [self parseEndPlacemark];
   } else if ([elementName isEqual:kGMUGroundOverlayElementName]) {


### PR DESCRIPTION
Fixes #216. I noticed that GMUKMLParser don't parse and don't save GMUPair objects to GMUStyleMap.
So i've added this logic to the GMUKMLParser.

Also, I faced with an issue that I can't make my overlays tappable after I used GMUGeometryRenderer to render geometries.
I found `mapOverlays` function that are not used. I think this function were made to be public but it's not in h file for some reasons.
I've made it public.

@domesticmouse Looking forward to have it merged.
Thanks.

 Test passing
  CLA submitted