### PR TITLE
Change properties type from string to NSobject as interface crashes a…

### DIFF
--- a/src/Geometry/Model/GMUFeature.h
+++ b/src/Geometry/Model/GMUFeature.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The properties of the geometry in the feature.
  */
-@property(nonatomic, nullable, readonly) NSDictionary<NSString *, NSString *> *properties;
+@property(nonatomic, nullable, readonly) NSDictionary<NSString *, NSObject *> *properties;
 
 /**
  * The bounding box of the geometry in the feature.
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithGeometry:(id<GMUGeometry>)geometry
                       identifier:(NSString * _Nullable)identifier
-                      properties:(NSDictionary<NSString *, NSString *> * _Nullable)properties
+                      properties:(NSDictionary<NSString *, NSObject *> * _Nullable)properties
                      boundingBox:(GMSCoordinateBounds * _Nullable)boundingBox;
 
 @end

--- a/src/Geometry/Model/GMUFeature.m
+++ b/src/Geometry/Model/GMUFeature.m
@@ -22,7 +22,7 @@
 
 - (instancetype)initWithGeometry:(id<GMUGeometry>)geometry
                       identifier:(NSString * _Nullable)identifier
-                      properties:(NSDictionary<NSString *, NSString *> * _Nullable)properties
+                      properties:(NSDictionary<NSString *, NSObject *> * _Nullable)properties
                      boundingBox:(GMSCoordinateBounds * _Nullable)boundingBox {
   if (self = [super init]) {
     _geometry = geometry;


### PR DESCRIPTION
Change properties type from string to NSObject as interface crashes and doesn't conform to spec #rfc7946
https://tools.ietf.org/html/rfc7946
The value of the properties member is an object (any JSON object or a JSON null value)