### PR TITLE
feat: Update Swift demo to use Swift 4.2

### DIFF
--- a/samples/SwiftDemoApp/SwiftDemoApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftDemoApp/SwiftDemoApp.xcodeproj/project.pbxproj
@@ -126,7 +126,6 @@
 				02B36ACA1D190D7E00EA3A86 /* Sources */,
 				02B36ACB1D190D7E00EA3A86 /* Frameworks */,
 				02B36ACC1D190D7E00EA3A86 /* Resources */,
-				093924E3B23836B266145193 /* [CP] Embed Pods Frameworks */,
 				6DB2DE912035DC43C1A4FD9E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -190,21 +189,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		093924E3B23836B266145193 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		530FFABA37157F6DC6FF2695 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -229,7 +213,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-resources.sh",
 				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -238,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -317,7 +301,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -356,7 +340,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -375,7 +359,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftDemoApp/SwiftDemoApp-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -390,7 +374,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftDemoApp/SwiftDemoApp-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/samples/SwiftDemoApp/SwiftDemoApp/AppDelegate.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/AppDelegate.swift
@@ -17,20 +17,18 @@ import GoogleMaps
 import UIKit
 
 // Change this key to a valid key registered with the demo app bundle id.
-let kMapsAPIKey = ""
+let mapsAPIKey = ""
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
-
-
-  func application(_ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    if kMapsAPIKey.isEmpty {
-      fatalError("Please provide an API Key using kMapsAPIKey")
+  
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    if mapsAPIKey.isEmpty {
+      fatalError("Please provide an API Key using mapsAPIKey")
     }
-    GMSServices.provideAPIKey(kMapsAPIKey)
+    GMSServices.provideAPIKey(mapsAPIKey)
     let masterViewControler = MasterViewController()
     let navigationController = UINavigationController(rootViewController: masterViewControler)
     window?.rootViewController = navigationController

--- a/samples/SwiftDemoApp/SwiftDemoApp/HeatmapViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/HeatmapViewController.swift
@@ -23,7 +23,7 @@ class HeatmapViewController: UIViewController, GMSMapViewDelegate {
   private var button: UIButton!
 
   private var gradientColors = [UIColor.green, UIColor.red]
-  private var gradientStartPoints = [0.2, 1.0] as? [NSNumber]
+  private var gradientStartPoints = [0.2, 1.0] as [NSNumber]
 
   override func loadView() {
     let camera = GMSCameraPosition.camera(withLatitude: -37.848, longitude: 145.001, zoom: 10)
@@ -39,7 +39,7 @@ class HeatmapViewController: UIViewController, GMSMapViewDelegate {
     heatmapLayer.radius = 80
     heatmapLayer.opacity = 0.8
     heatmapLayer.gradient = GMUGradient(colors: gradientColors,
-                                        startPoints: gradientStartPoints!,
+                                        startPoints: gradientStartPoints,
                                         colorMapSize: 256)
     addHeatmap()
 
@@ -73,6 +73,7 @@ class HeatmapViewController: UIViewController, GMSMapViewDelegate {
     heatmapLayer.weightedData = list
   }
 
+  @objc
   func removeHeatmap() {
     heatmapLayer.map = nil
     heatmapLayer = nil


### PR DESCRIPTION
Updating the Swift demo to use Swift 4.2. The demo with Swift 3 was unusable in the latest version of Xcode.