### PR TITLE
build(CocoaPods): speed up initial pod install by using CDN.

### DIFF
--- a/samples/ObjCDemoApp/Podfile
+++ b/samples/ObjCDemoApp/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '9.0'
 
 target 'ObjCDemoApp' do

--- a/samples/SwiftDemoApp/Podfile
+++ b/samples/SwiftDemoApp/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '9.0'
 
 target 'SwiftDemoApp' do

--- a/workspace/Podfile
+++ b/workspace/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '9.0'
 
 target 'DevApp' do


### PR DESCRIPTION
Speeding up initial `pod install` by using CDN instead of the CocoaPods master repo (i.e. if you don't have a `~/.cocoapods` directory yet and one needs to be initialized). See the [CocoaPods blog post](http://blog.cocoapods.org/CocoaPods-1.7.2/) for more info. I noticed a 50% speed up.

**Benchmark on Macbook Pro 2.6 GHz Intel Core i7**

| Method      | Time (in secs) |
| ------------- | ------------- |
| Master Repo  | 343  |
| CDN  |  162  |