### PR TITLE
feat: Remove version from podspec dependency.

### DIFF
--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "GoogleMapsUtils"
 
-  s.dependency 'GoogleMaps', '~> 3.7.0'
+  s.dependency 'GoogleMaps'
   s.static_framework = true
 
   s.subspec 'QuadTree' do |sp|


### PR DESCRIPTION
Remove specific dependency to GoogleMaps version 3.7.0. A regression introduced in a33e821f.

Fixes #275 🦕
