### PR TITLE
fix: Revert 4d9799d so that the lib is compatible with pod try

### DIFF
--- a/samples/ObjCDemoApp/Podfile
+++ b/samples/ObjCDemoApp/Podfile
@@ -1,4 +1,4 @@
-source 'https://cdn.cocoapods.org/'
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 
 target 'ObjCDemoApp' do

--- a/samples/SwiftDemoApp/Podfile
+++ b/samples/SwiftDemoApp/Podfile
@@ -1,4 +1,4 @@
-source 'https://cdn.cocoapods.org/'
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 
 target 'SwiftDemoApp' do

--- a/workspace/Podfile
+++ b/workspace/Podfile
@@ -1,4 +1,4 @@
-source 'https://cdn.cocoapods.org/'
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 
 target 'DevApp' do


### PR DESCRIPTION
Using CocoaPods CDN speeds up initialization of CocoaPods so that the master repo
doesn't need to be instantiated on first install. However, the CDN is a 1.8+ feature
and 1.8+ is not compatible with the pod try plugin (See: https://github.com/CocoaPods/cocoapods-try/issues/63).

As a workaround, reverting 4d9799d for now so that `pod try Google-Maps-iOS-Utils` works on CocoaPods versions < 1.8.