### PR TITLE
fix: Fix crash in GMUClusterManager

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -296,9 +296,11 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
                                  userData:item
                               clusterIcon:nil
                                  animated:shouldAnimate];
-        if (item.title && item.snippet) {
-          marker.title = item.title;
-          marker.snippet = item.snippet;
+        if ([item respondsToSelector:@selector(title)]) {
+            marker.title = item.title;
+        }
+        if ([item respondsToSelector:@selector(snippet)]) {
+            marker.snippet = item.snippet;
         }
       }
       [_mutableMarkers addObject:marker];

--- a/test/common/Model/GMUTestClusterItem.h
+++ b/test/common/Model/GMUTestClusterItem.h
@@ -20,7 +20,11 @@
 @interface GMUTestClusterItem : NSObject<GMUClusterItem>
 
 @property(nonatomic, readonly) CLLocationCoordinate2D position;
-- (instancetype)initWithPosition:(CLLocationCoordinate2D)position;
+@property(nonatomic, readonly, nullable) NSString *title;
+@property(nonatomic, readonly, nullable) NSString *snippet;
+
+- (instancetype _Nonnull)initWithPosition:(CLLocationCoordinate2D)position;
+- (instancetype _Nonnull)initWithPosition:(CLLocationCoordinate2D)position title:(nullable NSString *)title snippet:(nullable NSString *)snippet;
 
 @end
 

--- a/test/common/Model/GMUTestClusterItem.m
+++ b/test/common/Model/GMUTestClusterItem.m
@@ -22,10 +22,14 @@
 @implementation GMUTestClusterItem
 
 - (instancetype)initWithPosition:(CLLocationCoordinate2D)position {
-  if ((self = [super init])) {
+    return [self initWithPosition:position title:nil snippet:nil];
+}
+
+- (instancetype)initWithPosition:(CLLocationCoordinate2D)position title:(NSString *)title snippet:(NSString *)snippet {
     _position = position;
-  }
-  return self;
+    _title = title;
+    _snippet = snippet;
+    return self;
 }
 
 @end

--- a/test/unit/Clustering/GMUDefaultClusterRendererTest.m
+++ b/test/unit/Clustering/GMUDefaultClusterRendererTest.m
@@ -91,6 +91,22 @@ static const CLLocationCoordinate2D kCameraPosition = {-35, 151};
   XCTAssertEqual(markers[1].map, _mapView);
 }
 
+- (void)testAddingClusterItemsWithTitleAndSnippet {
+    NSMutableArray<id<GMUCluster>> *clusters = [[NSMutableArray<id<GMUCluster>> alloc] init];
+    GMUStaticCluster *cluster = [self clusterAroundPosition:kCameraPosition count:1 title:@"Title" snippet:@"Snippet"];
+    [clusters addObject:cluster];
+    
+    [_renderer renderClusters:clusters];
+    NSArray<GMSMarker *> *markers = [_renderer markers];
+    XCTAssertEqual(1, markers.count);
+    
+    GMSMarker *marker = markers[0];
+    XCTAssertTrue([marker.userData conformsToProtocol:@protocol(GMUClusterItem)]);
+    XCTAssertEqual(_mapView, marker.map);
+    XCTAssertEqual(@"Title", marker.title);
+    XCTAssertEqual(@"Snippet", marker.snippet);
+}
+
 // Small clusters should be expanded into markers (one per cluster item).
 - (void)testRenderClustersSmallClustersExpanded {
   // Arrange.
@@ -213,16 +229,22 @@ static const CLLocationCoordinate2D kCameraPosition = {-35, 151};
 // Returns a new cluster around a |position| with |count| items in it.
 - (GMUStaticCluster *)clusterAroundPosition:(CLLocationCoordinate2D)position
                                       count:(NSUInteger)count {
-  GMUStaticCluster *cluster = [[GMUStaticCluster alloc] initWithPosition:position];
-  while (count-- > 0) {
-    double deltaLatitude = (arc4random_uniform(200) - 100.0) / 100.0;
-    double deltaLongitude = (arc4random_uniform(200) - 100.0) / 100.0;
-    CLLocationCoordinate2D itemPosition = CLLocationCoordinate2DMake(
-        position.latitude + deltaLatitude, position.longitude + deltaLongitude);
-    [cluster addItem:[[GMUTestClusterItem alloc] initWithPosition:itemPosition]];
-  }
-  return cluster;
+    return [self clusterAroundPosition:position count:count title:nil snippet:nil];
+  
 }
 
+- (GMUStaticCluster *)clusterAroundPosition:(CLLocationCoordinate2D)position
+                                       count:(NSUInteger)count
+                                      title:(NSString *)title
+                                    snippet:(NSString *)snippet {
+    GMUStaticCluster *cluster = [[GMUStaticCluster alloc] initWithPosition:position];
+    while (count-- > 0) {
+        double deltaLatitude = (arc4random_uniform(200) - 100.0) / 100.0;
+        double deltaLongitude = (arc4random_uniform(200) - 100.0) / 100.0;
+        CLLocationCoordinate2D itemPosition = CLLocationCoordinate2DMake(position.latitude + deltaLatitude, position.longitude + deltaLongitude);
+        [cluster addItem:[[GMUTestClusterItem alloc] initWithPosition:itemPosition title: title snippet: snippet]];
+    }
+    return cluster;
+}
 @end
 


### PR DESCRIPTION
Fixes crash in GMUClusterManager by inspecting if a conforming
GMUClusterItem responds to the selectors title and snippet before
accessing it.

Closes #300.
