### PR TITLE
fix: Make title and snippet mutable for GMUClusterItem.

### DIFF
--- a/samples/SwiftDemoApp/SwiftDemoApp/ClusteringViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/ClusteringViewController.swift
@@ -52,7 +52,7 @@ class ClusteringViewController: UIViewController, GMUClusterManagerDelegate, GMS
     let algorithm = GMUNonHierarchicalDistanceBasedAlgorithm()
     let renderer = GMUDefaultClusterRenderer(mapView: mapView, clusterIconGenerator: iconGenerator)
     clusterManager = GMUClusterManager(map: mapView, algorithm: algorithm, renderer: renderer)
-
+    
     // Generate and add random items to the cluster manager.
     generateClusterItems()
 

--- a/src/Clustering/GMUClusterItem.h
+++ b/src/Clustering/GMUClusterItem.h
@@ -26,9 +26,8 @@
 @property(nonatomic, readonly) CLLocationCoordinate2D position;
 
 @optional
-@property(nonatomic, nullable, readonly) NSString* title;
+@property(nonatomic, copy, nullable) NSString* title;
 
-@optional
-@property(nonatomic, nullable, readonly) NSString* snippet;
+@property(nonatomic, copy, nullable) NSString* snippet;
 
 @end


### PR DESCRIPTION
The `readonly` keyword on `GMUClusterItem` title and snippet were
making title and snippet on `GMSMarker` immutable. Removing this keyword
and marking properties as `copy` to match `GMSMarker` fixes this.

Fixes #300
