### PR TITLE
refactor: Removing the unnecessary force unwrapping[!] for UITableViewCell

### DIFF
--- a/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
@@ -33,12 +33,8 @@ class MasterViewController: UITableViewController {
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) ->
       UITableViewCell {
     let cellIdentifier = "Cell"
-    let cell: UITableViewCell = {
-    guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) else {
-        return UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
-        }
-        return cell
-    }()
+    let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) ??
+        UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
         
     cell.accessoryType = .disclosureIndicator
     if let sample = samples[indexPath.item] as? [String: Any?] {

--- a/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
@@ -18,6 +18,7 @@ import UIKit
 
 class MasterViewController: UITableViewController {
   var samples: [Any] = []
+  let cellIdentifier = "Cell"
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -32,20 +33,18 @@ class MasterViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) ->
       UITableViewCell {
-    let cellIdentifier = "Cell"
-    var cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)
-       
-    if (cell == nil) {
-      cell = UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
-      cell!.accessoryType = .disclosureIndicator
-    }
-
+    let cell: UITableViewCell = {
+    guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) else {
+        return UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
+        }
+        return cell
+    }()
+    cell.accessoryType = .disclosureIndicator
     if let sample = samples[indexPath.item] as? [String: Any?] {
-      cell!.textLabel!.text = sample["title"] as? String
-      cell!.detailTextLabel!.text = sample["description"] as? String
+      cell.textLabel?.text = sample["title"] as? String
+      cell.detailTextLabel?.text = sample["description"] as? String
     }
-        
-    return cell!;
+    return cell
   }
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
@@ -18,7 +18,6 @@ import UIKit
 
 class MasterViewController: UITableViewController {
   var samples: [Any] = []
-  let cellIdentifier = "Cell"
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -33,7 +32,7 @@ class MasterViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) ->
       UITableViewCell {
-        
+    let cellIdentifier = "Cell"
     let cell: UITableViewCell = {
     guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) else {
         return UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)

--- a/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/MasterViewController.swift
@@ -33,17 +33,20 @@ class MasterViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) ->
       UITableViewCell {
+        
     let cell: UITableViewCell = {
     guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) else {
         return UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
         }
         return cell
     }()
+        
     cell.accessoryType = .disclosureIndicator
     if let sample = samples[indexPath.item] as? [String: Any?] {
       cell.textLabel?.text = sample["title"] as? String
       cell.detailTextLabel?.text = sample["description"] as? String
     }
+        
     return cell
   }
 


### PR DESCRIPTION
1. Moved `cellIdentifier` to variable declaration section.
2. Removed the unnecessary force unwrapping[!] for UITableViewCell.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
