### PR TITLE
fix: Adding missing -r flag when zipping .xcframework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
         echo "Creating XCFramework"
         xcodebuild -create-xcframework -framework ./Maps.framework-iphoneos.xcarchive/Products/Library/Frameworks/GoogleMapsUtils.framework -framework ./Maps.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/GoogleMapsUtils.framework -output ./GoogleMapsUtils.xcframework
-        zip ./GoogleMapsUtils.xcframework.zip ./GoogleMapsUtils.xcframework
+        zip -r ./GoogleMapsUtils.xcframework.zip ./GoogleMapsUtils.xcframework
 
     - name: Update Package.swift checksum
       run: |


### PR DESCRIPTION
Fixes #322 