### PR TITLE
fix(Clustering): Disappearing marker when zooming in.

### DIFF
--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -115,10 +115,15 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
   _clusters = [clusters copy];
 
-  NSArray *existingMarkers = _mutableMarkers;
+  NSMutableArray<GMSMarker *> *existingMarkers = _mutableMarkers;
   _mutableMarkers = [[NSMutableArray<GMSMarker *> alloc] init];
 
   [self addOrUpdateClusters:clusters animated:isZoomingIn];
+  
+  // If the marker was re-added, remove from existingMarkers which will be cleared
+  for (GMSMarker *visibleMarker in _mutableMarkers) {
+    [existingMarkers removeObject:visibleMarker];
+  }
 
   if (isZoomingIn) {
     [self clearMarkers:existingMarkers];


### PR DESCRIPTION
Fixes issue when zooming in on an unclustered marker. This was primarily an issue if you added a `GMSMarker` directly into the `GMUClusterManager` - it was not an issue for other objects conforming to `GMUClusterItem`.

Fixes #321 🦕
