### PR TITLE
feat: Adding MapPoint.

### DIFF
--- a/GoogleMapsUtils.xcodeproj/project.pbxproj
+++ b/GoogleMapsUtils.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		543C4FB8246A23C100821017 /* GMSMarker+GMUClusteritem.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D7847F2464DAAC00437147 /* GMSMarker+GMUClusteritem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		543C4FBA246A247C00821017 /* GMSMarker+GMUClusteritem.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D7847F2464DAAC00437147 /* GMSMarker+GMUClusteritem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		543C4FBB246A248000821017 /* GMSMarker+GMUClusteritem.m in Sources */ = {isa = PBXBuildFile; fileRef = 54D784802464DAAC00437147 /* GMSMarker+GMUClusteritem.m */; };
+		AA50CFFD2536274800869802 /* MapPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA29A440252E6E2800D69D87 /* MapPoint.swift */; };
+		AA50D0012536274800869802 /* MapPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA29A440252E6E2800D69D87 /* MapPoint.swift */; };
+		AA74F47E251E4F87003BFC8C /* MapPointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA74F47D251E4F87003BFC8C /* MapPointTest.swift */; };
 		AA8DE322245793AB003DBA7B /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA8DE31F245793AA003DBA7B /* GoogleMapsBase.framework */; };
 		AA8DE323245793AB003DBA7B /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA8DE320245793AB003DBA7B /* GoogleMapsCore.framework */; };
 		AA8DE324245793AB003DBA7B /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA8DE321245793AB003DBA7B /* GoogleMaps.framework */; };
@@ -250,6 +253,8 @@
 		54D7847F2464DAAC00437147 /* GMSMarker+GMUClusteritem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+GMUClusteritem.h"; sourceTree = "<group>"; };
 		54D784802464DAAC00437147 /* GMSMarker+GMUClusteritem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "GMSMarker+GMUClusteritem.m"; sourceTree = "<group>"; };
 		662F6FAE156096701716AEEC /* libPods-DevApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DevApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA29A440252E6E2800D69D87 /* MapPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapPoint.swift; path = src/GeometryUtils/MapPoint.swift; sourceTree = "<group>"; };
+		AA74F47D251E4F87003BFC8C /* MapPointTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPointTest.swift; sourceTree = "<group>"; };
 		AA8DE31F245793AA003DBA7B /* GoogleMapsBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleMapsBase.framework; path = Carthage/Build/iOS/GoogleMapsBase.framework; sourceTree = "<group>"; };
 		AA8DE320245793AB003DBA7B /* GoogleMapsCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleMapsCore.framework; path = Carthage/Build/iOS/GoogleMapsCore.framework; sourceTree = "<group>"; };
 		AA8DE321245793AB003DBA7B /* GoogleMaps.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleMaps.framework; path = Carthage/Build/iOS/GoogleMaps.framework; sourceTree = "<group>"; };
@@ -534,6 +539,7 @@
 		0242D1881C7C19A500557130 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				AA29A448252E6E2C00D69D87 /* GeometryUtils */,
 				AABFFEAD24578CAC0015D8C6 /* Clustering */,
 				AABFFECF24578CAC0015D8C6 /* Geometry */,
 				AABFFEC824578CAC0015D8C6 /* Heatmap */,
@@ -651,6 +657,22 @@
 				662F6FAE156096701716AEEC /* libPods-DevApp.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		AA29A448252E6E2C00D69D87 /* GeometryUtils */ = {
+			isa = PBXGroup;
+			children = (
+				AA29A440252E6E2800D69D87 /* MapPoint.swift */,
+			);
+			name = GeometryUtils;
+			sourceTree = "<group>";
+		};
+		AA74F47C251E4F66003BFC8C /* GeometryUtils */ = {
+			isa = PBXGroup;
+			children = (
+				AA74F47D251E4F87003BFC8C /* MapPointTest.swift */,
+			);
+			path = GeometryUtils;
 			sourceTree = "<group>";
 		};
 		AABFFEA524578CAC0015D8C6 /* QuadTree */ = {
@@ -873,9 +895,10 @@
 		AAE6BA0B2458C9EB0051CD31 /* unit */ = {
 			isa = PBXGroup;
 			children = (
-				3E7A8F3F24C2BB58000318C3 /* Heatmap */,
 				AAE6BA0C2458C9EB0051CD31 /* Clustering */,
 				AAE6BA162458C9EB0051CD31 /* Geometry */,
+				AA74F47C251E4F66003BFC8C /* GeometryUtils */,
+				3E7A8F3F24C2BB58000318C3 /* Heatmap */,
 				AAE6BA222458C9EB0051CD31 /* QuadTree */,
 			);
 			name = unit;
@@ -1087,7 +1110,7 @@
 				TargetAttributes = {
 					0242D1CB1C7C1C1F00557130 = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 1160;
+						LastSwiftMigration = 1200;
 					};
 					0242D1FD1C7D3AC300557130 = {
 						CreatedOnToolsVersion = 7.2.1;
@@ -1257,6 +1280,7 @@
 				AAE6BA622458CCA50051CD31 /* GMUFeatureTest.m in Sources */,
 				543C4FBB246A248000821017 /* GMSMarker+GMUClusteritem.m in Sources */,
 				AAE6BA552458CC670051CD31 /* GMUClusterManagerTest.m in Sources */,
+				AA74F47E251E4F87003BFC8C /* MapPointTest.swift in Sources */,
 				AAE6BA532458CC670051CD31 /* GMUGridBasedClusterAlgorithmTest.m in Sources */,
 				3EA2526624CB50A4003A7D07 /* GMUSimpleClusterAlgorithmTest.swift in Sources */,
 				AAE6BA652458CCA50051CD31 /* GMUGeometryCollectionTest.m in Sources */,
@@ -1269,6 +1293,7 @@
 				3A01F81B24EF47690054A305 /* HeatMapInterpolationTests.swift in Sources */,
 				3E7A8F4224C2BBDD000318C3 /* GMUWeightedLatLngTest.swift in Sources */,
 				AAE6BA5A2458CC670051CD31 /* GMUStaticClusterTest.m in Sources */,
+				AA50CFFD2536274800869802 /* MapPoint.swift in Sources */,
 				AAE6BA632458CCA50051CD31 /* GMULineStringTest.m in Sources */,
 				AAE6BA602458CCA50051CD31 /* GMUPlacemarkTest.m in Sources */,
 				AAE6BA572458CC670051CD31 /* GMUDefaultClusterIconGeneratorTest.m in Sources */,
@@ -1301,6 +1326,7 @@
 				AAA1DE33245790A0001CB03C /* GMUPolygon.m in Sources */,
 				AAA1DE2B24579086001CB03C /* GMUGeometryRenderer.m in Sources */,
 				AAA1DE4D245790CA001CB03C /* GQTPointQuadTree.m in Sources */,
+				AA50D0012536274800869802 /* MapPoint.swift in Sources */,
 				AAA1DE1A2457902D001CB03C /* GMUNonHierarchicalDistanceBasedAlgorithm.m in Sources */,
 				AAA1DE1424579010001CB03C /* GMUGridBasedClusterAlgorithm.m in Sources */,
 				AAA1DE2524579067001CB03C /* GMUDefaultClusterIconGenerator.m in Sources */,

--- a/src/GeometryUtils/MapPoint.swift
+++ b/src/GeometryUtils/MapPoint.swift
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreLocation
+
+/// Describes a point on the globe in a projected coordinate system.
+///
+/// The value of `x`, the longitude projection,  is in the  range [-1, 1].
+/// The axis direction behaves such that increasing `y` values go towards North,
+/// and increasing `x` values go towards East.
+///
+/// The point (0, 0) is the coordinate at lat, long (0, 0).
+public struct MapPoint {
+  var x: Double
+  var y: Double
+}
+
+public extension CLLocationCoordinate2D {
+  /// Projects this coordinate to the map and returns a MapPoint
+  var mapPoint: MapPoint {
+    return MapPoint(
+      x: mercatorX(longitude),
+      y: mercatorY(latitude)
+    )
+  }
+}
+
+public extension MapPoint {
+  /// Unprojects this point from the map
+  var location: CLLocationCoordinate2D {
+    return CLLocationCoordinate2D(
+      latitude: inverseMercatorLatitude(y),
+      longitude: inverseMercatorLongitude(x)
+    )
+  }
+
+  /// Returns the length of the segment from this to `to` in projected space.
+  /// The length is computed along the short path between the points potentially crossing the date line.
+  /// E.g. the distance between the points corresponding to San Francisco and Tokyo measures the segment that passes north of Hawaii crossing the date line.
+  func distance(to: MapPoint) -> Double {
+    let dy = self.y - to.y
+    let dx = self.x - to.x
+    var dx2 = dx * dx
+    if (dx2 > 1) {  // Equivalent to abs(dx) > 1.
+      let dxprim = 2 - abs(dx)
+      dx2 = dxprim * dxprim
+    }
+    return sqrt(dx2 + dy * dy)
+  }
+
+  /// Returns a linearly interpolated point on the segment `from` to `to` by `fraction`.
+  /// t==0 corresponds to `from`, t==1 corresponds to `to`.
+  ///
+  /// The interpolation takes place along the short path between the points potentially crossing the date line.
+  /// E.g. interpolating from San Francisco to Tokyo will pass north of Hawaii and cross the date line.
+  static func interpolate(from: MapPoint, to: MapPoint, fraction: Double) -> MapPoint {
+    let v = 1 - fraction
+    var ax = from.x
+    var bx = to.x
+
+    // Rotate towards positive only so that we can avoid abs() on normalizing interpolateX below.
+    let worldWidth = 2.0
+    if (ax < bx) {
+      ax += worldWidth
+    } else {
+      bx += worldWidth
+    }
+    var interpolateX = (ax * v) + (bx * fraction)
+    if (interpolateX > 1) {
+      interpolateX -= worldWidth
+    }
+    let interpolateY = (from.y * v) + (to.y * fraction)
+    return MapPoint(x: interpolateX, y: interpolateY)
+  }
+}
+
+private func inverseMercatorLatitude(_ y: Double) -> CLLocationDegrees {
+  return (2 * atan(exp(y * .pi)) - (.pi / 2)) * (180 / .pi)
+}
+
+private func inverseMercatorLongitude(_ x: Double) -> CLLocationDegrees {
+  return x * 180
+}
+
+private func mercatorX(_ longitude: CLLocationDegrees) -> Double {
+  return longitude / 180
+}
+
+private func mercatorY(_ latitude: CLLocationDegrees) -> Double {
+  let latitudeInRadians = latitude * (.pi / 180)
+  let mercatoryY = log(tan(latitudeInRadians * 0.5 + (.pi / 4)))
+  return mercatoryY / .pi
+}

--- a/src/GeometryUtils/MapPoint.swift
+++ b/src/GeometryUtils/MapPoint.swift
@@ -16,7 +16,7 @@ import CoreLocation
 
 /// Describes a point on the globe in a projected coordinate system.
 ///
-/// The value of `x`, the longitude projection,  is in the  range [-1, 1].
+/// The value of `x`, the longitude projection, is in the  range [-1, 1].
 /// The axis direction behaves such that increasing `y` values go towards North,
 /// and increasing `x` values go towards East.
 ///

--- a/test/unit/GeometryUtils/MapPointTest.swift
+++ b/test/unit/GeometryUtils/MapPointTest.swift
@@ -28,35 +28,38 @@ class MapPointTest : XCTestCase {
   private let northMapPoint = MapPoint(x: 0, y: 0.7754812)
   private let southMapPoint = MapPoint(x: 0, y: -0.7754812)
 
-  func testMapPointProject() {
-    XCTAssertEqual(westMapPoint.x, westCoordinate.mapPoint.x, accuracy: 1e-8)
-    XCTAssertEqual(eastMapPoint.x, eastCoordinate.mapPoint.x, accuracy: 1e-8)
-    XCTAssertEqual(northMapPoint.y, northCoordinate.mapPoint.y, accuracy: 1e-8)
-    XCTAssertEqual(southMapPoint.y, southCoordinate.mapPoint.y, accuracy: 1e-8)
+  private let mapPointPrecision = 1e-6
+  private let latLngPrecision = 1e-6
+
+  func testLocationMapPoint() {
+    XCTAssertEqual(westMapPoint.x, westCoordinate.mapPoint.x, accuracy: mapPointPrecision)
+    XCTAssertEqual(eastMapPoint.x, eastCoordinate.mapPoint.x, accuracy: mapPointPrecision)
+    XCTAssertEqual(northMapPoint.y, northCoordinate.mapPoint.y, accuracy: mapPointPrecision)
+    XCTAssertEqual(southMapPoint.y, southCoordinate.mapPoint.y, accuracy: mapPointPrecision)
   }
 
-  func testMapPointUnproject() {
-    let westUnproj = westMapPoint.location
-    XCTAssertEqual(westCoordinate.latitude, westUnproj.latitude, accuracy: 1e-6)
-    XCTAssertEqual(westCoordinate.longitude, westUnproj.longitude, accuracy: 1e-6)
+  func testMapPointLocation() {
+    let westLocation = westMapPoint.location
+    XCTAssertEqual(westCoordinate.latitude, westLocation.latitude, accuracy: latLngPrecision)
+    XCTAssertEqual(westCoordinate.longitude, westLocation.longitude, accuracy: latLngPrecision)
 
-    let eastUnproj = eastMapPoint.location
-    XCTAssertEqual(eastCoordinate.latitude, eastUnproj.latitude, accuracy: 1e-6)
-    XCTAssertEqual(eastCoordinate.longitude, eastUnproj.longitude, accuracy: 1e-6)
+    let eastLocation = eastMapPoint.location
+    XCTAssertEqual(eastCoordinate.latitude, eastLocation.latitude, accuracy: latLngPrecision)
+    XCTAssertEqual(eastCoordinate.longitude, eastLocation.longitude, accuracy: latLngPrecision)
 
-    let northUnproj = northMapPoint.location
-    XCTAssertEqual(northCoordinate.latitude, northUnproj.latitude, accuracy: 1e-6)
-    XCTAssertEqual(northCoordinate.longitude, northUnproj.longitude, accuracy: 1e-6)
+    let northLocation = northMapPoint.location
+    XCTAssertEqual(northCoordinate.latitude, northLocation.latitude, accuracy: latLngPrecision)
+    XCTAssertEqual(northCoordinate.longitude, northLocation.longitude, accuracy: latLngPrecision)
 
-    let southProj = southMapPoint.location
-    XCTAssertEqual(southCoordinate.latitude, southProj.latitude, accuracy: 1e-6)
-    XCTAssertEqual(southCoordinate.longitude, southProj.longitude, accuracy: 1e-6)
+    let southLocation = southMapPoint.location
+    XCTAssertEqual(southCoordinate.latitude, southLocation.latitude, accuracy: latLngPrecision)
+    XCTAssertEqual(southCoordinate.longitude, southLocation.longitude, accuracy: latLngPrecision)
   }
 
   func testDistance() {
     let a = MapPoint(x: -0.7, y: 1)
     let b = MapPoint(x: 0.9, y: 1)
-    XCTAssertEqual(a.distance(to: b), 2 - (b.x - a.x), accuracy: 1e-6)
+    XCTAssertEqual(a.distance(to: b), 2 - (b.x - a.x), accuracy: mapPointPrecision)
   }
 
   func testInterpolate() {
@@ -64,16 +67,16 @@ class MapPointTest : XCTestCase {
     let b = MapPoint(x: 0.9, y: 1)
     let c = MapPoint(x: -0.7, y: 0)
     XCTAssertEqual(
-      a.x, MapPoint.interpolate(from: a, to: b, fraction: 0).x, accuracy: 1e-6
+      a.x, MapPoint.interpolate(from: a, to: b, fraction: 0).x, accuracy: mapPointPrecision
     )
     XCTAssertEqual(
-      b.x, MapPoint.interpolate(from: a, to: b, fraction: 1).x, accuracy: 1e-6
+      b.x, MapPoint.interpolate(from: a, to: b, fraction: 1).x, accuracy: mapPointPrecision
     )
     XCTAssertEqual(
-      (a.x + b.x - 2) / 2, MapPoint.interpolate(from: a, to: b, fraction: 0.5).x, accuracy: 1e-6
+      (a.x + b.x - 2) / 2, MapPoint.interpolate(from: a, to: b, fraction: 0.5).x, accuracy: mapPointPrecision
     )
     XCTAssertEqual(
-      (a.y + c.y) / 2, MapPoint.interpolate(from: a, to: c, fraction: 0.5).y, accuracy: 1e-6
+      (a.y + c.y) / 2, MapPoint.interpolate(from: a, to: c, fraction: 0.5).y, accuracy: mapPointPrecision
     )
   }
 }

--- a/test/unit/GeometryUtils/MapPointTest.swift
+++ b/test/unit/GeometryUtils/MapPointTest.swift
@@ -1,0 +1,79 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreLocation
+import XCTest
+@testable import GoogleMapsUtils
+
+class MapPointTest : XCTestCase {
+
+  private let westCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: -180)
+  private let eastCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 180)
+  private let northCoordinate = CLLocationCoordinate2D(latitude: 80, longitude: 0)
+  private let southCoordinate = CLLocationCoordinate2D(latitude: -80, longitude: 0)
+
+  private let westMapPoint = MapPoint(x: -1, y: 0)
+  private let eastMapPoint = MapPoint(x: 1, y: 0)
+  private let northMapPoint = MapPoint(x: 0, y: 0.7754812)
+  private let southMapPoint = MapPoint(x: 0, y: -0.7754812)
+
+  func testMapPointProject() {
+    XCTAssertEqual(westMapPoint.x, westCoordinate.mapPoint.x, accuracy: 1e-8)
+    XCTAssertEqual(eastMapPoint.x, eastCoordinate.mapPoint.x, accuracy: 1e-8)
+    XCTAssertEqual(northMapPoint.y, northCoordinate.mapPoint.y, accuracy: 1e-8)
+    XCTAssertEqual(southMapPoint.y, southCoordinate.mapPoint.y, accuracy: 1e-8)
+  }
+
+  func testMapPointUnproject() {
+    let westUnproj = westMapPoint.location
+    XCTAssertEqual(westCoordinate.latitude, westUnproj.latitude, accuracy: 1e-6)
+    XCTAssertEqual(westCoordinate.longitude, westUnproj.longitude, accuracy: 1e-6)
+
+    let eastUnproj = eastMapPoint.location
+    XCTAssertEqual(eastCoordinate.latitude, eastUnproj.latitude, accuracy: 1e-6)
+    XCTAssertEqual(eastCoordinate.longitude, eastUnproj.longitude, accuracy: 1e-6)
+
+    let northUnproj = northMapPoint.location
+    XCTAssertEqual(northCoordinate.latitude, northUnproj.latitude, accuracy: 1e-6)
+    XCTAssertEqual(northCoordinate.longitude, northUnproj.longitude, accuracy: 1e-6)
+
+    let southProj = southMapPoint.location
+    XCTAssertEqual(southCoordinate.latitude, southProj.latitude, accuracy: 1e-6)
+    XCTAssertEqual(southCoordinate.longitude, southProj.longitude, accuracy: 1e-6)
+  }
+
+  func testDistance() {
+    let a = MapPoint(x: -0.7, y: 1)
+    let b = MapPoint(x: 0.9, y: 1)
+    XCTAssertEqual(a.distance(to: b), 2 - (b.x - a.x), accuracy: 1e-6)
+  }
+
+  func testInterpolate() {
+    let a = MapPoint(x: -0.7, y: 1)
+    let b = MapPoint(x: 0.9, y: 1)
+    let c = MapPoint(x: -0.7, y: 0)
+    XCTAssertEqual(
+      a.x, MapPoint.interpolate(from: a, to: b, fraction: 0).x, accuracy: 1e-6
+    )
+    XCTAssertEqual(
+      b.x, MapPoint.interpolate(from: a, to: b, fraction: 1).x, accuracy: 1e-6
+    )
+    XCTAssertEqual(
+      (a.x + b.x - 2) / 2, MapPoint.interpolate(from: a, to: b, fraction: 0.5).x, accuracy: 1e-6
+    )
+    XCTAssertEqual(
+      (a.y + c.y) / 2, MapPoint.interpolate(from: a, to: c, fraction: 0.5).y, accuracy: 1e-6
+    )
+  }
+}


### PR DESCRIPTION
Adding `MapPoint.swift` which provides alternative Swift-friendly APIs to functions within the Maps SDK [GMSGeometryUtils](https://developers.google.com/maps/documentation/ios-sdk/reference/group___geometry_utils) module.

* `MapPoint` can be used in place of `GMSMapPoint`
* The extension property on `CLLocationCoordinate2D`, `mapPoint`, can be used in place of `GMSProject`
* The property on `MapPoint`, `location`, can be used in place of `GMSUnproject`
* The static function on `MapPoint`, `interpolate(from:, to:, fraction:)` can be used in place of `GMSMapPointInterpolate`
* The function on `MapPoint`, `distance(to: )`, can be used in place of `GMSMapPointDistance`