### PR TITLE
fix: nil userData on marker when clustering/declustering.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
         brew install carthage
 
     - name: Carthage update
-      run: carthage update --platform iOS
+      run: ./carthage.sh update --platform iOS
 
     - name: Carthage build
-      run: carthage build --no-skip-current
+      run: ./carthage.sh build --no-skip-current
 
     - name: Build DevApp
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Carthage update
       run: |
-        carthage build
+        ./carthage.sh build
 
     - name: Create XCFramework
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,10 @@ jobs:
         sudo gem install cocoapods
 
     - name: Carthage update
-      run: carthage update --platform iOS
+      run: ./carthage.sh update --platform iOS
 
     - name: Carthage build
-      run: carthage build --no-skip-current
+      run: ./carthage.sh build --no-skip-current
 
     - name: CocoaPods spec lint
       run: pod spec lint

--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'GoogleMaps'
   s.static_framework = true
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
   s.subspec 'QuadTree' do |sp|
     sp.public_header_files = "src/#{sp.base_name}/**/*.h"

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_iphonesimulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(PLATFORM_NAME)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"

--- a/src/Clustering/View/GMUDefaultClusterRenderer.m
+++ b/src/Clustering/View/GMUDefaultClusterRenderer.m
@@ -403,7 +403,9 @@ static const double kGMUAnimationDuration = 0.5;  // seconds.
 
 - (void)clearMarkers:(NSArray<GMSMarker *> *)markers {
   for (GMSMarker *marker in markers) {
-    marker.userData = nil;
+    if ([marker.userData conformsToProtocol:@protocol(GMUCluster)]) {
+      marker.userData = nil;
+    }
     marker.map = nil;
   }
 }


### PR DESCRIPTION
When clustering/declustering, the `userData` property of a marker can be nil'd. This is due to markers being removed from the map when the zoom level changes.
For example, when the zoom level changes and the marker representing a cluster should no longer be displayed, this marker is cleared. However, markers that don't
represent clusters were incorrectly cleared but this only happens if you add a `GMSMarker` directly to the `GMUClusterManager` and not if you are using another 
class conforming to `GMUClusterItem`. The fix here is to only clear the `userData` field if the marker being cleared represents a cluster.

Fixes #349 🦕
