### PR TITLE
feat: Support Simulator on ARM Macs

### DIFF
--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -23,8 +23,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'GoogleMaps'
   s.static_framework = true
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
   s.subspec 'QuadTree' do |sp|
     sp.public_header_files = "src/#{sp.base_name}/**/*.h"

--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.module_name = "GoogleMapsUtils"
   s.swift_version = '5.0'
 
-  s.dependency 'GoogleMaps', '>= 7.3'
+  s.dependency 'GoogleMaps', '~> 7.3'
   s.static_framework = true
 
   s.subspec 'QuadTree' do |sp|

--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -14,14 +14,14 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/googlemaps/google-maps-ios-utils"
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.authors      = "Google Inc."
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '13.0'
   s.source       = { :git => "https://github.com/googlemaps/google-maps-ios-utils.git",
                      :tag => "v#{s.version.to_s}" }
   s.requires_arc = true
   s.module_name = "GoogleMapsUtils"
   s.swift_version = '5.0'
 
-  s.dependency 'GoogleMaps'
+  s.dependency 'GoogleMaps', '>= 7.3'
   s.static_framework = true
 
   s.subspec 'QuadTree' do |sp|

--- a/samples/ObjCDemoApp/ObjCDemoApp.xcodeproj/project.pbxproj
+++ b/samples/ObjCDemoApp/ObjCDemoApp.xcodeproj/project.pbxproj
@@ -197,7 +197,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ObjCDemoApp/Pods-ObjCDemoApp-resources.sh",
-				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -332,7 +333,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = ObjCDemoApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -346,7 +347,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = ObjCDemoApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/samples/ObjCDemoApp/Podfile
+++ b/samples/ObjCDemoApp/Podfile
@@ -1,8 +1,8 @@
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '11.0'
+source 'https://cdn.cocoapods.org/'
+platform :ios, '13.0'
 
 target 'ObjCDemoApp' do
-    use_frameworks!
-  pod 'GoogleMaps', '4.0.0'
+  use_frameworks!
+  pod 'GoogleMaps', '>= 7.3'
   pod 'Google-Maps-iOS-Utils', :path => '../..'
 end

--- a/samples/ObjCDemoApp/Podfile
+++ b/samples/ObjCDemoApp/Podfile
@@ -3,6 +3,6 @@ platform :ios, '13.0'
 
 target 'ObjCDemoApp' do
   use_frameworks!
-  pod 'GoogleMaps', '>= 7.3'
+  pod 'GoogleMaps', '~> 7.3'
   pod 'Google-Maps-iOS-Utils', :path => '../..'
 end

--- a/samples/SwiftDemoApp/Podfile
+++ b/samples/SwiftDemoApp/Podfile
@@ -3,6 +3,6 @@ platform :ios, '13.0'
 
 target 'SwiftDemoApp' do
   use_frameworks!
-  pod 'GoogleMaps', '>= 7.3'
+  pod 'GoogleMaps', '~> 7.3'
   pod 'Google-Maps-iOS-Utils', :path => '../..', :testspecs => ['Tests']
 end

--- a/samples/SwiftDemoApp/Podfile
+++ b/samples/SwiftDemoApp/Podfile
@@ -1,8 +1,8 @@
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '11.0'
+source 'https://cdn.cocoapods.org/'
+platform :ios, '13.0'
 
 target 'SwiftDemoApp' do
   use_frameworks!
-  pod 'GoogleMaps', '4.0.0'
+  pod 'GoogleMaps', '>= 7.3'
   pod 'Google-Maps-iOS-Utils', :path => '../..', :testspecs => ['Tests']
 end

--- a/samples/SwiftDemoApp/SwiftDemoApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftDemoApp/SwiftDemoApp.xcodeproj/project.pbxproj
@@ -216,7 +216,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SwiftDemoApp/Pods-SwiftDemoApp-resources.sh",
-				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -360,7 +361,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftDemoApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -379,7 +380,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftDemoApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.gmsutils.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/samples/SwiftDemoApp/SwiftDemoApp/GeoJSONViewController.swift
+++ b/samples/SwiftDemoApp/SwiftDemoApp/GeoJSONViewController.swift
@@ -35,4 +35,5 @@ class GeoJSONViewController: UIViewController {
     geoJsonParser.parse()
     renderer = GMUGeometryRenderer(map: mapView, geometries: geoJsonParser.features)
     renderer.render()
+  }
 }


### PR DESCRIPTION
Fixes #391

Google Maps 7.3.0's CocoaPods version now [uses XCFramework](https://developers.google.com/maps/documentation/ios-sdk/release-notes), so Google-Maps-iOS-Utils should not use `EXCLUDED_ARCHS` anymore.