### PR TITLE
chore: semantic release dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,12 @@ jobs:
       uses: cycjimmy/semantic-release-action@v3.4.1
       with:
         extra_plugins: |
-          "@semantic-release/commit-analyzer"
-          "@semantic-release/release-notes-generator"
+          "@semantic-release/commit-analyzer@8.0.1"
+          "@semantic-release/release-notes-generator@9.0.3"
           "@google/semantic-release-replace-plugin"
-          "@semantic-release/exec"
-          "@semantic-release/git"
-          "@semantic-release/github"
+          "@semantic-release/exec@5.0.0"
+          "@semantic-release/git@9.0.1"
+          "@semantic-release/github@7.2.3"
       env:
         GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Workaround specifying Node 14 requires specifying older versions of semantic-release based on Node 14.