### PR TITLE
feat: add support for google maps sdk v8

### DIFF
--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.module_name = "GoogleMapsUtils"
   s.swift_version = '5.0'
 
-  s.dependency 'GoogleMaps', '~> 7.3'
+  s.dependency 'GoogleMaps', '>= 7.3', '< 9.0'
   s.static_framework = true
 
   s.subspec 'QuadTree' do |sp|


### PR DESCRIPTION
Google Maps SDK for iOS v8.0.0 was released with no other breaking changes than freezing support for iOS 13, meaning it should be safe to support it in Google Maps iOS Utils. See [v8 release notes](https://developers.google.com/maps/documentation/ios-sdk/release-notes#May_17_2023).

I did some brief testing and experienced no issues while using Google Maps SDK for iOS v8.0.0.