### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,14 +27,12 @@ jobs:
         run: echo '${{ toJson(steps.release) }}'
         continue-on-error: true
 
-      # Call the Publish workflow to publish to CocoaPods when a release is cut.
-      # Note the "if" statement on all commands to make sure that publishing
-      # only happens when a release is cut.
-
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
+      # Call the Publish workflow to publish to CocoaPods when a release is cut.
+      # Note the "if" statement makes sure that publishing
+      # only happens when a release is cut.
       - if: ${{ steps.release.outputs.release_created }}
         name: Start publish
         uses: ./.github/workflows/publish.yml

--- a/Google-Maps-iOS-Utils.podspec
+++ b/Google-Maps-iOS-Utils.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.changelog    = "https://github.com/googlemaps/google-maps-ios-utils/blob/main/CHANGELOG.md"
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.authors      = "Google Inc."
-  s.platform     = :ios, '14.0'
+  s.platform     = :ios, '15.0'
   s.source       = { :git => "https://github.com/googlemaps/google-maps-ios-utils.git",
                      :tag => "v#{s.version.to_s}" }
   s.source_files = "Sources/GoogleMapsUtilsObjC/include/*.{h,m}", "Sources/GoogleMapsUtils/**/*.{swift}"
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.module_name = "GoogleMapsUtils"
   s.swift_version = '5.9'
 
-  s.dependency 'GoogleMaps', '~> 8.0'
+  s.dependency 'GoogleMaps', '~> 9.0'
   s.static_framework = true
 
   s.test_spec 'Tests' do |unit_tests|

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googlemaps/ios-maps-sdk",
       "state" : {
-        "revision" : "bd392d7d844b49ec6795871a3c25edd01ab839f2",
-        "version" : "8.4.0"
+        "revision" : "0cd72dd45109b0225dd920ff17e0362a96489ec0",
+        "version" : "9.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
   name: "GoogleMapsUtils",
   platforms: [
-    .iOS(.v14),
+    .iOS(.v15),
   ],
   products: [
     .library(
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/googlemaps/ios-maps-sdk",
-      from: "8.0.0"),
+      from: "9.0.0"),
     .package(
       url: "https://github.com/erikdoe/ocmock.git",
       revision: "fe1661a3efed11831a6452f4b1a0c5e6ddc08c3d"),
@@ -39,8 +39,6 @@ let package = Package(
       name: "GoogleMapsUtilsObjC",
       dependencies: [
         .product(name: "GoogleMaps", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsBase", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsCore", package: "ios-maps-sdk"),
       ],
       publicHeadersPath: "include",
       cSettings: [
@@ -55,8 +53,6 @@ let package = Package(
       dependencies: [
         .target(name: "GoogleMapsUtilsObjC"),
         .product(name: "GoogleMaps", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsBase", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsCore", package: "ios-maps-sdk"),
       ]
     ),
     .target(
@@ -85,8 +81,6 @@ let package = Package(
         "GoogleMapsUtilsObjC",
         "GoogleMapsUtilsTestsHelper",
         .product(name: "GoogleMaps", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsBase", package: "ios-maps-sdk"),
-        .product(name: "GoogleMapsCore", package: "ios-maps-sdk"),
       ],
       path: "Tests/GoogleMapsUtilsSwiftTests",
       resources: [.process("Resources")]

--- a/Podfile.template
+++ b/Podfile.template
@@ -1,10 +1,10 @@
 # [START maps_ios_utils_podfile_template]
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '14.0'
+platform :ios, '15.0'
 
 target 'YOUR_APPLICATION_TARGET_NAME_HERE' do
   use_frameworks!
-  pod 'GoogleMaps', '8.4.0'
+  pod 'GoogleMaps', '9.0.0'
   pod 'Google-Maps-iOS-Utils', '5.0.0' # x-release-please-version
 end
 # [END maps_ios_utils_podfile_template]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ range of applications using the [Google Maps SDK for iOS][sdk].
 
 3. Select the
     [version](https://github.com/googlemaps/google-maps-ios-utils/releases)
-    of the Maps SDK for iOS Utility Library that you want to use. For new projects, we recommend specifying the latest version and using the "Exact Version" option. See Release Notes for [this library](https://github.com/googlemaps/google-maps-ios-utils/releases) and the [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/release-notes) to select the correct version for you.
+    of the Maps SDK for iOS Utility Library that you want to use. For new projects, we recommend specifying the latest version and using the "Up to next Major" option. See Release Notes for [this library](https://github.com/googlemaps/google-maps-ios-utils/releases) and the [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/release-notes) to select the correct version for you.
 
     - (Recommended) Version 6.x supports the Maps SDK for iOS v9.x
     - Version 5.0 supports the Maps SDK for iOS v8.x

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ range of applications using the [Google Maps SDK for iOS][sdk].
   use_frameworks!
 
   target 'TARGET_NAME' do
-    pod 'GoogleMaps', '8.0.0'
+    pod 'GoogleMaps', '9.0.0'
     pod 'Google-Maps-iOS-Utils', '5.0.0' # x-release-please-start-version
   end
   ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
       "draft": false,
       "prerelease": false,
       "extra-files": [
-        "README.md",
         "Google-Maps-iOS-Utils.podspec",
         "Podfile.template"
       ]

--- a/samples/ObjCDemoApp/Podfile
+++ b/samples/ObjCDemoApp/Podfile
@@ -1,8 +1,8 @@
 source 'https://cdn.cocoapods.org/'
-platform :ios, '14.0'
+platform :ios, '15.0'
 
 target 'ObjCDemoApp' do
   use_frameworks!
-  pod 'GoogleMaps', '8.4.0'
+  pod 'GoogleMaps', '9.0.0'
   pod 'Google-Maps-iOS-Utils', :path => '../..'
 end

--- a/samples/SwiftDemoApp/Podfile
+++ b/samples/SwiftDemoApp/Podfile
@@ -1,7 +1,7 @@
-platform :ios, '14.0'
+platform :ios, '15.0'
 
 target 'SwiftDemoApp' do
   use_frameworks!
-  pod 'GoogleMaps', '8.4.0'
+  pod 'GoogleMaps', '9.0.0'
   pod 'Google-Maps-iOS-Utils', :path => '../..', :testspecs => ['Tests']
 end


### PR DESCRIPTION
1. The release worfklow is failing because the call to the publish workflow requires checkout first, which must not be handled under a separate conditional.

2. Release Please is unable to distinguish between version numbers of this package that should be bumped up with each release vs other strings that represent version numbers but shouldn't be bumped. This causes an extra manual commit on the release PR to correct the edits that release-please makes. Since the README has 3 strings that shouldn't be bumped and 1 instance that should be bumped, we will manually update the bump until Release Please can support a more detailed regex.