### PR TITLE
chore: fix release-to-publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,14 +27,12 @@ jobs:
         run: echo '${{ toJson(steps.release) }}'
         continue-on-error: true
 
-      # Call the Publish workflow to publish to CocoaPods when a release is cut.
-      # Note the "if" statement on all commands to make sure that publishing
-      # only happens when a release is cut.
-
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
+      # Call the Publish workflow to publish to CocoaPods when a release is cut.
+      # Note the "if" statement makes sure that publishing
+      # only happens when a release is cut.
       - if: ${{ steps.release.outputs.release_created }}
         name: Start publish
         uses: ./.github/workflows/publish.yml

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ range of applications using the [Google Maps SDK for iOS][sdk].
 
 3. Select the
     [version](https://github.com/googlemaps/google-maps-ios-utils/releases)
-    of the Maps SDK for iOS Utility Library that you want to use. For new projects, we recommend specifying the latest version and using the "Exact Version" option. See Release Notes for [this library](https://github.com/googlemaps/google-maps-ios-utils/releases) and the [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/release-notes) to select the correct version for you.
+    of the Maps SDK for iOS Utility Library that you want to use. For new projects, we recommend specifying the latest version and using the "Up to next Major" option. See Release Notes for [this library](https://github.com/googlemaps/google-maps-ios-utils/releases) and the [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/release-notes) to select the correct version for you.
 
     - (Recommended) Version 6.x supports the Maps SDK for iOS v9.x
     - Version 5.0 supports the Maps SDK for iOS v8.x

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
       "draft": false,
       "prerelease": false,
       "extra-files": [
-        "README.md",
         "Google-Maps-iOS-Utils.podspec",
         "Podfile.template"
       ]


### PR DESCRIPTION
1. The release worfklow is failing because the call to the publish workflow requires checkout first, which must not be handled under a separate conditional.
 
2. Release Please is unable to distinguish between version numbers of this package that should be bumped up with each release vs other strings that represent version numbers but shouldn't be bumped. This causes an extra manual commit on the release PR to correct the edits that release-please makes. Since the README has 3 strings that shouldn't be bumped and 1 instance that should be bumped, we will manually update the bump until Release Please can support a more detailed regex (feature request in https://github.com/googleapis/release-please/issues/2345)

- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
