### PR TITLE
refactor(`feature/Geometry-Swift`): Refactored Geometry models & Protocols in swift.

### DIFF
--- a/Sources/GoogleMapsUtils/Geometry/Models/GMULineString1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Models/GMULineString1.swift
@@ -1,0 +1,26 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMaps
+
+/// Instances of this class represent a LineString object.
+/// TO-DO: Rename the class to `GMULineString` once the linking is done and remove the objective c class.
+struct GMULineString1: GMUGeometry1 {
+    // MARK: - Properties
+    /// The type of the geometry.
+    var type: String
+    /// The path of the LineString.
+    private(set) var path: GMSPath
+}
+

--- a/Sources/GoogleMapsUtils/Geometry/Models/GMUPair1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Models/GMUPair1.swift
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/// Instances of this class represent a geometry Style. It is used to define the
+/// stylings of any number of GMUGeometry objects.
+/// TO-DO: Rename the class to `GMUPair` once the linking is done and remove the objective c class.
+struct GMUPair1 {
+    // MARK: - Properties
+    private(set) var key: String
+    private(set) var styleUrl: String
+}

--- a/Sources/GoogleMapsUtils/Geometry/Models/GMUPlacemark1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Models/GMUPlacemark1.swift
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Represents a placemark which is either a Point, LineString, Polygon, or MultiGeometry. Contains
+/// the properties and styles of the place.
+/// TO-DO: Rename the class to `GMUPlacemarkSwift & GMUGeometryContainer` once the linking is done and remove the objective c class.
+struct GMUPlacemark1: GMUGeometryContainer1 {
+    // MARK: - Properties
+    /// The geometry object in the container.
+    var geometry: GMUGeometry
+    /// Style information that should be applied to the contained geometry object.
+    var style: GMUStyle
+    /// The name element of the placemark.
+    private(set) var title: String
+    /// The description element of the placemark.
+    private(set) var snippet: String
+    /// The StyleUrl element of the placemark; used to reference a style defined in the file.
+    private(set) var styleUrl: String
+
+}

--- a/Sources/GoogleMapsUtils/Geometry/Models/GMUStyle1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Models/GMUStyle1.swift
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/// Instances of this class represent a geometry Style. It is used to define the
+/// stylings of any number of GMUGeometry objects.
+/// TO-DO: Rename the class to `GMUStyle` once the linking is done and remove the objective c class.
+struct GMUStyle1 {
+    // MARK: - Properties
+    /// The unique identifier of the style
+    private(set) var styleID: String
+    /// The color for the stroke of a LineString or Polygon.
+    private(set) var strokeColor: UIColor
+    /// The color for the fill of a Polygon.
+    private(set) var fillColor: UIColor
+    /// The width of a LineString
+    private(set) var width: Float
+    /// The scale that a Point's icon should be rendered at.
+    private(set) var scale: Float
+    /// The direction, in degrees, that a Point's icon should be rendered at.
+    private(set) var heading: Float
+    /// The position within an icon that is anchored to the Point.
+    private(set) var anchor: CGPoint
+    /// The href for the icon to be used for a Point.
+    private(set) var iconUrl: String
+    /// The title to use for a Point.
+    private(set) var title: String
+    /// Whether the Polygon has a defined fill color.
+    private(set) var hasFill: Bool
+    /// Whether the LineString or Polygon has a defined stroke color.
+    private(set) var hasStroke: Bool
+}

--- a/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometry1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometry1.swift
@@ -1,0 +1,21 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/// Defines a generic geometry object.
+/// TO-DO: Rename the class to `GMUGeometryContainer` once the linking is done and remove the objective c class.
+protocol GMUGeometry1 {
+    /// The type of the geometry.
+    var type: String { get }
+}

--- a/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometryContainer1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometryContainer1.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Defines a generic geometry container.
-/// TO-DO: Rename the class to `GMUGeometryContainer` once the linking is done and remove the objective c class.
+/// TO-DO: Rename the class to `GMUGeometryContainer` once the linking is done and remove the objective c class
 protocol GMUGeometryContainer1 {
     /// The geometry object in the container.
     var geometry: GMUGeometry { get }

--- a/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometryContainer1.swift
+++ b/Sources/GoogleMapsUtils/Geometry/Protocols/GMUGeometryContainer1.swift
@@ -1,0 +1,22 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Defines a generic geometry container.
+/// TO-DO: Rename the class to `GMUGeometryContainer` once the linking is done and remove the objective c class.
+protocol GMUGeometryContainer1 {
+    /// The geometry object in the container.
+    var geometry: GMUGeometry { get }
+    /// Style information that should be applied to the contained geometry object.
+    var style: GMUStyle { get set }
+}


### PR DESCRIPTION
List of Refactored Files, Adding Obj-C file for reference:

1. [GMULineString](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMULineString.h)
2. [GMUPair](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUPair.h)
3. [GMUPlacemark](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUPlacemark.h)
4. [GMUStyle](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUStyle.h)
5. [GMUGeometry](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUGeometry.h)
6. [GMUGeometryContainer](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUGeometryContainer.h)

