### PR TITLE
refactor: Translate & Modernised `GMUCluster` & `GMUClusterItem` class of `Clustering` module.

### DIFF
--- a/Sources/GoogleMapsUtils/Clustering/Protocols/GMUCluster1.swift
+++ b/Sources/GoogleMapsUtils/Clustering/Protocols/GMUCluster1.swift
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreLocation
+
+/// TO-DO: Rename the class to `GMUCluster` once the linking is done and remove the objective c class.
+/// Defines a generic cluster object, with read-only properties.
+///
+protocol GMUCluster1 {
+
+    /// Returns the position of the cluster.
+    var position: CLLocationCoordinate2D { get }
+
+    /// Returns the number of items in the cluster.
+    var count: Int { get }
+
+    /// Returns a copy of the list of items in the cluster.
+    var items: [GMUClusterItem1] { get }
+}

--- a/Sources/GoogleMapsUtils/Clustering/Protocols/GMUClusterItem1.swift
+++ b/Sources/GoogleMapsUtils/Clustering/Protocols/GMUClusterItem1.swift
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreLocation
+
+/// TO-DO: Rename the class to `GMUClusterItem1` once the linking is done and remove the objective c class.
+/// This protocol defines the contract for a cluster item, with read-only properties.
+///
+protocol GMUClusterItem1 {
+
+    /// Returns the position of the item.
+    var position: CLLocationCoordinate2D { get }
+
+    /// Returns an optional title for the item.
+    var title: String? { get }
+
+    /// Returns an optional snippet for the item.
+    var snippet: String? { get }
+}


### PR DESCRIPTION
### Description:

1. Translate & Modernised `GMUCluster` & `GMUClusterItem`

### Reference:

Translate & Modified files, Adding Obj-C file for reference:

1. [GMUCluster](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUCluster.h)
2. [GMUClusterItem](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUClusterItem.h)
