### PR TITLE
refactor: Translate & Modernise `GMUWrappingDictionaryKey` class, `GMUWrappingDictionaryKeyTest`(UT) of `Clustering` module.

### DIFF
--- a/Sources/GoogleMapsUtils/Clustering/Algorithms/WrappingDictionaryKey/GMUWrappingDictionaryKey1.swift
+++ b/Sources/GoogleMapsUtils/Clustering/Algorithms/WrappingDictionaryKey/GMUWrappingDictionaryKey1.swift
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/// TO-DO: Rename the class to `GMUWrappingDictionaryKey` once the linking is done and remove the objective c class.
+/// Wraps an object that does not implement Hashable to be used as Dictionary keys.
+///
+final class GMUWrappingDictionaryKey1: NSObject, NSCopying {
+
+    // MARK: - Properties
+    /// The wrapped object that doesn't implement Hashable.
+    private let currentObject: Any
+
+    // MARK: - Initializers
+    /// Initializer that takes an object to be wrapped.
+    init(object: Any) {
+        self.currentObject = object
+    }
+
+    // MARK: - Override's
+    /// Forward the hash value to the underlying object.
+    override var hash: Int {
+        // Use the `hash` property of the wrapped object to provide the hash value.
+        return (currentObject as AnyObject).hash
+    }
+
+    /// Forward the equality check to the underlying object.
+    override func isEqual(_ object: Any?) -> Bool {
+        // If both instances are the same, return true.
+        if self === object as AnyObject {
+            return true
+        }
+
+        // Check if the object is of the same type, and then compare the underlying objects.
+        guard let other = object as? GMUWrappingDictionaryKey1 else {
+            return false
+        }
+        return (self.currentObject as AnyObject).isEqual(other.currentObject)
+    }
+
+    // MARK: - `copy`
+    /// Method to create a copy of the instance.
+    func copy(with zone: NSZone? = nil) -> Any {
+        // Create a new instance and copy the wrapped object.
+        let newKey = GMUWrappingDictionaryKey1(object: currentObject)
+        return newKey
+    }
+}

--- a/Tests/GoogleMapsUtilsSwiftTests/unit/Clustering/GMUWrappingDictionaryKeyTest.swift
+++ b/Tests/GoogleMapsUtilsSwiftTests/unit/Clustering/GMUWrappingDictionaryKeyTest.swift
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import GoogleMapsUtils
+
+final class GMUWrappingDictionaryKeyTest: XCTestCase {
+    
+    func testEqualityAndHash() {
+        let object = "Test object"
+        let key1 = GMUWrappingDictionaryKey1(object: object)
+        let key2 = GMUWrappingDictionaryKey1(object: object)
+
+        // Testing reference inequality (since they are different instances)
+        XCTAssertFalse(key1 === key2)
+
+        // Testing value equality
+        XCTAssertEqual(key1, key2)
+
+        // Testing hash equality
+        XCTAssertEqual(key1.hash, key2.hash)
+    }
+
+    func testUnequalityAndHash() {
+        let object1 = "Test object1"
+        let key1 = GMUWrappingDictionaryKey1(object: object1)
+        let object2 = "Test object2"
+        let key2 = GMUWrappingDictionaryKey1(object: object2)
+
+        // Testing reference inequality
+        XCTAssertFalse(key1 === key2)
+
+        // Testing value inequality
+        XCTAssertNotEqual(key1, key2)
+
+        // Testing hash inequality
+        XCTAssertNotEqual(key1.hash, key2.hash)
+    }
+
+    func testCopy() {
+        let object = "Test object"
+        let key1 = GMUWrappingDictionaryKey1(object: object as AnyObject)
+        guard let key2 = key1.copy() as? GMUWrappingDictionaryKey1 else {
+            XCTFail("Copy failed to return a valid GMUWrappingDictionaryKey")
+            return
+        }
+
+        // Testing value equality after copying
+        XCTAssertEqual(key1, key2)
+
+        // Testing hash equality after copying
+        XCTAssertEqual(key1.hash, key2.hash)
+    }
+}
+


### PR DESCRIPTION
### Description:

1. Translate & Modernised `GMUWrappingDictionaryKey`
2. Translate & Modernise `GMUWrappingDictionaryKeyTest`, Unit Test.

### Reference:

Translate & Modified files, Adding Obj-C file for reference:

1. [GMUWrappingDictionaryKey](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtilsObjC/include/GMUWrappingDictionaryKey.m)
3. [GMUWrappingDictionaryKeyTest](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Tests/GoogleMapsUtilsObjCTests/unit/GMUWrappingDictionaryKeyTest.m)


### Validations:
<img width="461" alt="Screenshot 2024-10-01 at 12 55 20 PM" src="https://github.com/user-attachments/assets/9ee22383-a82d-4c34-b1b3-c15c24b79d4b">



