### PR TITLE
chore: fixed broken URLs

### DIFF
--- a/docs/GeometryUtils.md
+++ b/docs/GeometryUtils.md
@@ -4,8 +4,8 @@ Geometry Utilities
 The utility library contains Swift-friendly extensions of the [GMSGeometryUtils](https://developers.google.com/maps/documentation/ios-sdk/reference/group___geometry_utils) module of the Maps SDK for iOS. Rather than using C-Style functions in `GMSGeometryUtils`, you can use the Swift classes and extensions defined in this library.
 
 See:
-* [MapPoint](https://github.com/googlemaps/google-maps-ios-utils/blob/main/src/GeometryUtils/MapPoint.swift)
-* [CLLocationCoordinate2D+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/src/GeometryUtils/CLLocationCoordinate2D%2BGeometryUtils.swift)
-* [GMSPath+GeometryUtils.swfit](https://github.com/googlemaps/google-maps-ios-utils/blob/main/src/GeometryUtils/GMSPath%2BGeometryUtils.swift)
-* [GMSPolygon+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/src/GeometryUtils/GMSPolygon%2BGeometryUtils.swift)
-* [GMSPolyline+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/src/GeometryUtils/GMSPolyline%2BGeometryUtils.swift)
+* [MapPoint](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtils/GeometryUtils/MapPoint.swift)
+* [CLLocationCoordinate2D+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtils/GeometryUtils/CLLocationCoordinate2D%2BGeometryUtils.swift)
+* [GMSPath+GeometryUtils.swfit](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtils/GeometryUtils/GMSPath%2BGeometryUtils.swift)
+* [GMSPolygon+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtils/GeometryUtils/GMSPolygon%2BGeometryUtils.swift)
+* [GMSPolyline+GeometryUtils.swift](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Sources/GoogleMapsUtils/GeometryUtils/GMSPolyline%2BGeometryUtils.swift)


### PR DESCRIPTION
The following PR fixes some broken URLs in the [GeometryUtils](https://github.com/googlemaps/google-maps-ios-utils/blob/main/docs/GeometryUtils.md) README file. Now the links are pointing out to the correct URL.