### PR TITLE
chore: update release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,19 +1,17 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "include-component-in-tag": false,
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {
       "bootstrap-sha": "b56b39cec0e3d5938ddadbfeb4d3fec541ebbb5e",
       "changelog-path": "CHANGELOG.md",
-      "release-type": "simple",
-      "include-component-in-tag": false,
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": false,
       "extra-files": [
         "Google-Maps-iOS-Utils.podspec",
         "Podfile.template"
       ]
     }
-  },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+  }
 }


### PR DESCRIPTION
Formatting based on https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile

Although this is a single-package repo, the configfile README indicates we should set most options at the top level of the JSON and only a couple of properties are set in the package-specific config.
