### PR TITLE
refactor: Translate & Modernise `GMUClusterManagerTests` test class from Clustering test module. [code cov: 92.4%]

### DIFF
--- a/GoogleMapsUtils.xcodeproj/project.pbxproj
+++ b/GoogleMapsUtils.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E3ABBF02D5BC28F00D42DE6 /* MockGMSMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3ABBEF2D5BC28D00D42DE6 /* MockGMSMapView.swift */; };
 		3EA5DBC22D4DD6C5009463B7 /* LatLngRadians.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DBA02D4DD6C5009463B7 /* LatLngRadians.swift */; };
 		3EA5DBC32D4DD6C5009463B7 /* GMUClusterIconGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DB822D4DD6C5009463B7 /* GMUClusterIconGenerator.swift */; };
 		3EA5DBC42D4DD6C5009463B7 /* GMUPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DB942D4DD6C5009463B7 /* GMUPair.swift */; };
@@ -114,6 +115,12 @@
 		3EA5DC7B2D4DD755009463B7 /* GeoJSON_FeatureCollection_Test.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 3EA5DC122D4DD755009463B7 /* GeoJSON_FeatureCollection_Test.geojson */; };
 		3EA5DC7D2D4DD7E6009463B7 /* GMUGeometryRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DC7C2D4DD7E6009463B7 /* GMUGeometryRendererTest.swift */; };
 		3EA5DC7F2D4DD853009463B7 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 3EA5DC7E2D4DD853009463B7 /* GoogleMaps.bundle */; };
+		3EA5DDAF2D5BA5F9009463B7 /* GMUClusterManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDAE2D5BA5F8009463B7 /* GMUClusterManagerTests.swift */; };
+		3EA5DDB12D5BA632009463B7 /* MockClusterAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB02D5BA631009463B7 /* MockClusterAlgorithm.swift */; };
+		3EA5DDB32D5BA68D009463B7 /* MockCluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB22D5BA68B009463B7 /* MockCluster.swift */; };
+		3EA5DDB52D5BA6C3009463B7 /* MockClusterRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB42D5BA6C1009463B7 /* MockClusterRenderer.swift */; };
+		3EA5DDB72D5BA6D0009463B7 /* MockClusterManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */; };
+		3EA5DDB92D5BA6FF009463B7 /* MockMapDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +134,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3E3ABBEF2D5BC28D00D42DE6 /* MockGMSMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGMSMapView.swift; sourceTree = "<group>"; };
 		3EA5DB432D4DD6B0009463B7 /* GoogleMapsUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMapsUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3EA5DB682D4DD6C5009463B7 /* GMUGridBasedClusterAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUGridBasedClusterAlgorithm.swift; sourceTree = "<group>"; };
 		3EA5DB6A2D4DD6C5009463B7 /* GMUNonHierarchicalDistanceBasedAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUNonHierarchicalDistanceBasedAlgorithm.swift; sourceTree = "<group>"; };
@@ -234,6 +242,12 @@
 		3EA5DC482D4DD755009463B7 /* GQTPointQuadTreeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GQTPointQuadTreeTest.swift; sourceTree = "<group>"; };
 		3EA5DC7C2D4DD7E6009463B7 /* GMUGeometryRendererTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUGeometryRendererTest.swift; sourceTree = "<group>"; };
 		3EA5DC7E2D4DD853009463B7 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
+		3EA5DDAE2D5BA5F8009463B7 /* GMUClusterManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUClusterManagerTests.swift; sourceTree = "<group>"; };
+		3EA5DDB02D5BA631009463B7 /* MockClusterAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClusterAlgorithm.swift; sourceTree = "<group>"; };
+		3EA5DDB22D5BA68B009463B7 /* MockCluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCluster.swift; sourceTree = "<group>"; };
+		3EA5DDB42D5BA6C1009463B7 /* MockClusterRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClusterRenderer.swift; sourceTree = "<group>"; };
+		3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClusterManagerDelegate.swift; sourceTree = "<group>"; };
+		3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMapDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -661,6 +675,12 @@
 		3EA5DC262D4DD755009463B7 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				3E3ABBEF2D5BC28D00D42DE6 /* MockGMSMapView.swift */,
+				3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */,
+				3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */,
+				3EA5DDB42D5BA6C1009463B7 /* MockClusterRenderer.swift */,
+				3EA5DDB22D5BA68B009463B7 /* MockCluster.swift */,
+				3EA5DDB02D5BA631009463B7 /* MockClusterAlgorithm.swift */,
 				3EA5DC252D4DD755009463B7 /* MockGMUClusterItem.swift */,
 			);
 			path = Mocks;
@@ -670,6 +690,7 @@
 			isa = PBXGroup;
 			children = (
 				3EA5DC262D4DD755009463B7 /* Mocks */,
+				3EA5DDAE2D5BA5F8009463B7 /* GMUClusterManagerTests.swift */,
 				3EA5DC272D4DD755009463B7 /* GMUClusterAlgorithmTest.swift */,
 				3EA5DC282D4DD755009463B7 /* GMUDefaultClusterIconGeneratorTest.swift */,
 				3EA5DC292D4DD755009463B7 /* GMUGridBasedClusterAlgorithmTest.swift */,
@@ -980,6 +1001,7 @@
 				3EA5DC4F2D4DD755009463B7 /* GQTPointQuadTreeItemMock.swift in Sources */,
 				3EA5DC502D4DD755009463B7 /* GMUGridBasedClusterAlgorithmTest.swift in Sources */,
 				3EA5DC512D4DD755009463B7 /* GMUClusterAlgorithmTest.swift in Sources */,
+				3EA5DDB92D5BA6FF009463B7 /* MockMapDelegate.swift in Sources */,
 				3EA5DC522D4DD755009463B7 /* GMUStyleTest.swift in Sources */,
 				3EA5DC532D4DD755009463B7 /* GMUTestClusterItem.swift in Sources */,
 				3EA5DC7D2D4DD7E6009463B7 /* GMUGeometryRendererTest.swift in Sources */,
@@ -991,16 +1013,22 @@
 				3EA5DC592D4DD755009463B7 /* GQTPointQuadTreeTest.swift in Sources */,
 				3EA5DC5A2D4DD755009463B7 /* GMUPolygonTest.swift in Sources */,
 				3EA5DC5B2D4DD755009463B7 /* LatLngRadiansTest.swift in Sources */,
+				3EA5DDB52D5BA6C3009463B7 /* MockClusterRenderer.swift in Sources */,
 				3EA5DC5C2D4DD755009463B7 /* GMUGeoJSONParserTest.swift in Sources */,
 				3EA5DC5D2D4DD755009463B7 /* GMUWrappingDictionaryKeyTest.swift in Sources */,
+				3EA5DDB12D5BA632009463B7 /* MockClusterAlgorithm.swift in Sources */,
+				3EA5DDAF2D5BA5F9009463B7 /* GMUClusterManagerTests.swift in Sources */,
 				3EA5DC5E2D4DD755009463B7 /* GMUStaticClusterTest.swift in Sources */,
 				3EA5DC5F2D4DD755009463B7 /* GMUGeometryCollectionTest.swift in Sources */,
 				3EA5DC602D4DD755009463B7 /* GMUNonHierarchicalDistanceBasedAlgorithmTest.swift in Sources */,
 				3EA5DC612D4DD755009463B7 /* GMUKMLParserTest.swift in Sources */,
+				3E3ABBF02D5BC28F00D42DE6 /* MockGMSMapView.swift in Sources */,
 				3EA5DC622D4DD755009463B7 /* MockTest.swift in Sources */,
 				3EA5DC632D4DD755009463B7 /* GMUPointTest.swift in Sources */,
 				3EA5DC642D4DD755009463B7 /* GMUFeatureTest.swift in Sources */,
 				3EA5DC652D4DD755009463B7 /* GMULineStringTest.swift in Sources */,
+				3EA5DDB32D5BA68D009463B7 /* MockCluster.swift in Sources */,
+				3EA5DDB72D5BA6D0009463B7 /* MockClusterManagerDelegate.swift in Sources */,
 				3EA5DC662D4DD755009463B7 /* MockGMUClusterItem.swift in Sources */,
 				3EA5DC672D4DD755009463B7 /* GQTPointQuadTreeMock.swift in Sources */,
 				3EA5DC682D4DD755009463B7 /* GMUGroundOverlayTest.swift in Sources */,

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUClusterManagerTests.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUClusterManagerTests.swift
@@ -1,0 +1,283 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import GoogleMaps
+
+@testable import GoogleMapsUtils
+
+class GMUClusterManagerTests: XCTestCase {
+
+    // MARK: - Properties
+    var mapView: MockGMSMapView!
+    var camera: GMSCameraPosition!
+    var algorithm: MockClusterAlgorithm!
+    var renderer: MockClusterRenderer!
+    var clusterManager: GMUClusterManager!
+    var delegate: MockClusterManagerDelegate!
+    var mapDelegate: MockMapDelegate!
+    private let kCameraPosition: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: CLLocationDegrees(-35), longitude: CLLocationDegrees(151))
+    private let kCameraZoom: Float = 1.0
+
+    // MARK: - Setup()
+    override func setUp() {
+        super.setUp()
+        GMSServices.provideAPIKey("MOCK_API_KEY")
+        mapView = MockGMSMapView()
+        camera = GMSCameraPosition(target: kCameraPosition, zoom: kCameraZoom)
+        mapView.mockCamera = camera
+        algorithm = MockClusterAlgorithm()
+        renderer = MockClusterRenderer()
+        delegate = MockClusterManagerDelegate()
+        mapDelegate = MockMapDelegate()
+        clusterManager = GMUClusterManager(mapView: mapView, algorithm: algorithm, renderer: renderer)
+        clusterManager.setDelegate(delegate, mapDelegate: mapDelegate)
+    }
+
+    // MARK: - Teardown
+    override func tearDown() {
+        algorithm = nil
+        renderer = nil
+        delegate = nil
+        mapDelegate = nil
+        clusterManager = nil
+        mapView = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+    func testInitMapDelegateNotHookedByDefault() {
+        // Act.
+        clusterManager = GMUClusterManager(mapView: mapView, algorithm: algorithm, renderer: renderer)
+        // Assert
+        XCTAssertNil(mapView.delegate, "MapView delegate should not be set by default")
+    }
+
+    func testInit() {
+        // Assert
+        XCTAssertEqual(clusterManager.algorithm as? MockClusterAlgorithm, algorithm)
+        XCTAssertEqual(clusterManager.delegate as? MockClusterManagerDelegate, delegate)
+        XCTAssertEqual(clusterManager.mapDelegate as? MockMapDelegate, mapDelegate)
+    }
+
+    func testAddItem() {
+        // Arrange.
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        algorithm.addItems([item1])
+        // Act.
+        clusterManager.addItem(item1)
+    }
+
+    func testAddItems() {
+        // Arrange.
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        let item2 = MockGMUClusterItem(position: CLLocationCoordinate2D(latitude: 1, longitude: 1))
+        algorithm.addItems([item1, item2])
+        // Act.
+        clusterManager.addItems([item1, item2])
+    }
+
+    func testRemoveItem() {
+        // Arrange.
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        algorithm.removeItem(item1)
+        clusterManager.addItem(item1)
+        // Act.
+        clusterManager.removeItem(item1)
+    }
+
+    func testClearItems() {
+        // Arrange.
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        let item2 = MockGMUClusterItem(position: CLLocationCoordinate2D(latitude: 1, longitude: 1))
+        algorithm.clearItems()
+        clusterManager.addItems([item1, item2])
+        // Act.
+        let requestCount = clusterManager.currentClusterRequestCount
+        clusterManager.clearItems()
+        // Assert
+        XCTAssertEqual(clusterManager.currentClusterRequestCount, requestCount + 1)
+    }
+
+    func testCluster() {
+        // Arrange.
+        let clusters = [MockCluster(position: kCameraPosition, items: [])]
+        _ = algorithm.clusters(atZoom: kCameraZoom)
+        renderer.renderClusters(clusters)
+        // Act.
+        clusterManager.cluster()
+    }
+
+    func testCameraChangedReclusterRequested() {
+        // Arrange.
+        let clusters = [MockCluster(position: kCameraPosition, items: [])]
+        _ = algorithm.clusters(atZoom: kCameraZoom)
+        renderer.renderClusters(clusters)
+        // Intial cluster.
+        clusterManager.cluster()
+        // Act.
+        mapView.mockCamera = GMSCameraPosition(target: kCameraPosition, zoom: kCameraZoom + 2)
+        clusterManager.observeValue(forKeyPath: "camera", of: mapView, change: nil, context: nil)
+        // Assert
+        XCTAssertEqual(clusterManager.currentClusterRequestCount, 1)
+    }
+    
+    func testCameraChangedALittleReclusterNotRequested() {
+        // Arrange.
+        let clusters = [MockCluster(position: kCameraPosition, items: [])]
+        _ = algorithm.clusters(atZoom: kCameraZoom)
+        renderer.renderClusters(clusters)
+        // Intial cluster.
+        clusterManager.cluster()
+        // Act.
+        mapView.mockCamera = GMSCameraPosition(target: kCameraPosition, zoom: kCameraZoom + 0.3)
+        clusterManager.observeValue(forKeyPath: "camera", of: mapView, change: nil, context: nil)
+        // Assert
+        XCTAssertEqual(clusterManager.currentClusterRequestCount, 0)
+    }
+    
+    func testTapOnClusterMarkerEventRaised() {
+        // Arrange.
+        let cluster1 = MockCluster(position: kCameraPosition, items: [])
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        let marker = GMSMarker()
+        marker.map = mapView
+        marker.userData = cluster1
+        // Expect and reject.
+        _ = delegate.clusterManager(clusterManager, didTapCluster: cluster1)
+        _ = delegate.clusterManager(clusterManager, didTapClusterItem: item1)
+        // Act.
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        // Assert
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled, "Expected mapView(_:didTap:) to be called on the map delegate")
+    }
+
+    func testTapOnClusterItemMarkerNoDelegateEventRaisedOnMapDelegate() {
+        // Arrange.
+        let cluster1 = MockCluster(position: kCameraPosition, items: [])
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        let marker = GMSMarker()
+        marker.map = mapView
+        marker.userData = item1
+        // Expect and reject.
+        _ = delegate.clusterManager(clusterManager, didTapCluster: cluster1)
+        _ = delegate.clusterManager(clusterManager, didTapClusterItem: item1)
+        // Act.
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        // Assert
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled, "Expected mapView(_:didTap:) to be called on the map delegate")
+    }
+    
+        
+    func testTapOnClusterItemMarkerDelegateReturnsNoEventRaisedOnMapDelegate() {
+        // Arrange.
+        let item1 = MockGMUClusterItem(position: kCameraPosition)
+        let marker = GMSMarker()
+        marker.map = mapView
+        marker.userData = item1
+        clusterManager.setDelegate(delegate, mapDelegate: mapDelegate)
+        
+        // Act.
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        // Assert
+        XCTAssertFalse(delegate.clusterManager(clusterManager, didTapClusterItem: item1),
+                       "Expected clusterManager(_:didTapClusterItem:) to return false")
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled,
+                      "Expected mapView(_:didTap:) to be called on map delegate")
+    }
+
+    func testTapOnClusterMarkerDelegateReturnsNoEventRaisedOnMapDelegate() {
+        // Arrange.
+        let cluster1 = MockCluster(position: kCameraPosition, items: [])
+        let marker = GMSMarker()
+        marker.map = mapView
+        marker.userData = cluster1
+        clusterManager.setDelegate(delegate, mapDelegate: mapDelegate)
+        // Act.
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        // Assert
+        XCTAssertFalse(delegate.clusterManager(clusterManager, didTapCluster: cluster1),
+                       "Expected clusterManager(_:didTapCluster:) to return false")
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled,
+                      "Expected mapView(_:didTap:) to be called on map delegate")
+    }
+    
+    func testSetMapDelegate() {
+        // Arrange.
+        let clusterManager = GMUClusterManager(mapView: mapView,
+                                               algorithm: MockClusterAlgorithm(),
+                                               renderer: MockClusterRenderer())
+        let mockMapDelegate = MockMapDelegate()
+        // Act
+        clusterManager.setMapDelegate(mockMapDelegate)
+        // Assert
+        XCTAssertTrue(mapView.delegate === clusterManager, "Expected mapView's delegate to be set to clusterManager")
+        XCTAssertTrue(clusterManager.mapDelegate === mockMapDelegate, "Expected mapDelegate to be stored correctly")
+    }
+    
+    func testTapOnNormalMarkerEventRaisedOnMapDelegate() {
+        // Arrange.
+        let mapDelegate = MockMapDelegate()
+        let marker = GMSMarker()
+        marker.map = mapView
+        // Act
+        clusterManager.setDelegate(nil, mapDelegate: mapDelegate)
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        // Assert
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled,
+                      "Expected mapView(_:didTap:) to be called on map delegate")
+    }
+    
+    func testMapViewDidTapOverlay() {
+        // Arrange.
+        let mockMapDelegate = MockMapDelegate()
+        let overlay = GMSCircle(position: kCameraPosition, radius: 100)
+        // Act
+        clusterManager.setMapDelegate(mockMapDelegate)
+        clusterManager.mapView(mapView, didTap: overlay)
+        // Assert
+        XCTAssertTrue(mockMapDelegate.didTapOverlayCalled, "Expected mapView(_:didTap:) to be forwarded to the map delegate")
+    }
+
+    func testMapEventsForwardedToMapDelegate() {
+        // Arrange.
+        let mapDelegate = MockMapDelegate()
+        let marker = GMSMarker()
+        let cameraPosition = GMSCameraPosition.camera(withTarget: kCameraPosition, zoom: 10)
+        
+        // Act
+        clusterManager.setDelegate(nil, mapDelegate: mapDelegate)
+        clusterManager.mapView(mapView, willMove: true)
+        clusterManager.mapView(mapView, didChange: cameraPosition)
+        clusterManager.mapView(mapView, idleAt: cameraPosition)
+        clusterManager.mapView(mapView, didTapAt: kCameraPosition)
+        clusterManager.mapView(mapView, didLongPressAt: kCameraPosition)
+        clusterManager.mapView(mapView, didTapInfoWindowOf: marker)
+        clusterManager.mapView(mapView, didLongPressInfoWindowOf: marker)
+        _ = clusterManager.mapView(mapView, didTap: marker)
+        _ = clusterManager.mapView(mapView, markerInfoWindow: marker)
+        _ = clusterManager.mapView(mapView, markerInfoContents: marker)
+        clusterManager.mapView(mapView, didCloseInfoWindowOf: marker)
+        clusterManager.mapView(mapView, didBeginDragging: marker)
+        clusterManager.mapView(mapView, didDrag: marker)
+        clusterManager.mapView(mapView, didEndDragging: marker)
+        clusterManager.mapView(mapView, didTapPOIWithPlaceID: "", name: "", location: kCameraPosition)
+        _ = clusterManager.didTapMyLocationButton(for: mapView)
+        clusterManager.mapViewDidStartTileRendering(mapView)
+        clusterManager.mapViewDidFinishTileRendering(mapView)
+        // Assert
+        XCTAssertTrue(mapDelegate.didTapMarkerCalled, "Expected various map events to be forwarded to the map delegate")
+    }
+
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockCluster.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockCluster.swift
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreLocation
+
+@testable import GoogleMapsUtils
+
+/// A mock implementation of `GMUCluster` for testing purposes.
+final class MockCluster: GMUCluster {
+
+    // MARK: - Properties
+    /// The geographic position of the cluster.
+    var position: CLLocationCoordinate2D
+    /// The items contained within the cluster.
+    var items: [GMUClusterItem]
+    /// The number of items in the cluster.
+    var count: Int {
+        return items.count
+    }
+
+    // MARK: - Initializer
+    
+    /// Initializes a mock cluster with a given position and items.
+    /// - Parameters:
+    ///   - position: The location of the cluster.
+    ///   - items: The list of cluster items.
+    init(position: CLLocationCoordinate2D, items: [GMUClusterItem]) {
+        self.position = position
+        self.items = items
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterAlgorithm.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterAlgorithm.swift
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import GoogleMapsUtils
+
+/// A mock implementation of `GMUClusterAlgorithm` for testing purposes.
+final class MockClusterAlgorithm: GMUClusterAlgorithm, Equatable {
+
+    // MARK: - Properties
+    /// Stores the list of cluster items.
+    private var items: [GMUClusterItem] = []
+
+    // MARK: - Equatable Conformance
+    /// Compares two instances of `MockClusterAlgorithm`.
+    static func == (lhs: MockClusterAlgorithm, rhs: MockClusterAlgorithm) -> Bool {
+        return true
+    }
+
+    // MARK: - Cluster Management Methods
+    /// Adds multiple items to the cluster.
+    /// - Parameter items: The items to be added.
+    func addItems(_ items: [GMUClusterItem]) {
+        self.items.append(contentsOf: items)
+    }
+
+    /// Removes a specific item from the cluster.
+    /// - Parameter item: The item to be removed.
+    func removeItem(_ item: GMUClusterItem) {
+        self.items.removeAll {
+            $0.position.latitude == item.position.latitude &&
+            $0.position.longitude == item.position.longitude
+        }
+    }
+
+    /// Clears all items from the cluster.
+    func clearItems() {
+        items.removeAll()
+    }
+
+    // MARK: - GMUClusterAlgorithm Conformance
+    /// Generates clusters based on the current zoom level.
+    /// - Parameter zoom: The zoom level.
+    /// - Returns: An array of `GMUCluster` objects.
+    func clusters(atZoom zoom: Float) -> [GMUCluster] {
+        guard let firstItem = items.first else { return [] }
+        return [MockCluster(position: firstItem.position, items: items)]
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterManagerDelegate.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterManagerDelegate.swift
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import GoogleMapsUtils
+
+/// A mock implementation of `GMUClusterManagerDelegate` for testing purposes.
+final class MockClusterManagerDelegate: GMUClusterManagerDelegate, Equatable {
+
+    // MARK: - Equatable Conformance
+    /// Compares two instances of `MockClusterManagerDelegate`.
+    static func == (lhs: MockClusterManagerDelegate, rhs: MockClusterManagerDelegate) -> Bool {
+        return true
+    }
+
+    // MARK: - GMUClusterManagerDelegate Methods
+    /// Called when a cluster is tapped.
+    func clusterManager(_ clusterManager: GMUClusterManager, didTapCluster cluster: GMUCluster) -> Bool {
+        return false
+    }
+
+    /// Called when a cluster item is tapped.
+    func clusterManager(_ clusterManager: GMUClusterManager, didTapClusterItem clusterItem: GMUClusterItem) -> Bool {
+        return false
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterRenderer.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterRenderer.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import GoogleMapsUtils
+
+/// A mock implementation of `GMUClusterRenderer` for testing purposes.
+final class MockClusterRenderer: GMUClusterRenderer {
+
+    // MARK: - Properties
+    /// Stores the last rendered clusters for verification in tests.
+    private(set) var lastRenderedClusters: [GMUCluster]?
+
+    // MARK: - GMUClusterRenderer Conformance
+    /// Mocks the rendering of clusters by storing them.
+    func renderClusters(_ clusters: [GMUCluster]) {
+        lastRenderedClusters = clusters
+    }
+    
+    /// Updates the cluster rendering. This is a no-op in the mock.
+    func update() {}
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSMapView.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSMapView.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMaps
+
+@testable import GoogleMapsUtils
+
+/// A mock subclass of `GMSMapView` used for testing purposes.
+final class MockGMSMapView: GMSMapView {
+
+    // MARK: - Properties
+    /// A mock camera position to override the default camera.
+    var mockCamera: GMSCameraPosition?
+
+    // MARK: - Overridden Properties
+    /// Overrides the `camera` property to return the mock camera if set, otherwise calls the superclass implementation.
+    override var camera: GMSCameraPosition {
+        get { return mockCamera ?? super.camera }
+        set { mockCamera = newValue }
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockMapDelegate.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockMapDelegate.swift
@@ -1,0 +1,112 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMaps
+
+@testable import GoogleMapsUtils
+
+/// A mock implementation of `GMSMapViewDelegate` for testing purposes.
+///
+final class MockMapDelegate: GMSMapViewDelegate, Equatable {
+
+    // MARK: - Properties
+    var didTapMarkerCalled = false
+    var didTapOverlayCalled = false
+    var hash: Int = 0
+    var description: String = ""
+    var superclass: AnyClass?
+
+    // MARK: - GMSMapViewDelegate Methods
+    func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
+        didTapMarkerCalled = true
+        return true
+    }
+
+    func mapView(_ mapView: GMSMapView, didTap overlay: GMSOverlay) {
+        didTapOverlayCalled = true
+    }
+    
+    func mapView(_ mapView: GMSMapView, willMove gesture: Bool) {}
+    func mapView(_ mapView: GMSMapView, didChange position: GMSCameraPosition) {}
+    func mapView(_ mapView: GMSMapView, idleAt position: GMSCameraPosition) {}
+    func mapView(_ mapView: GMSMapView, didLongPressAt coordinate: CLLocationCoordinate2D) {}
+    func mapView(_ mapView: GMSMapView, didTapInfoWindowOf marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didLongPressInfoWindowOf marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didTapAt coordinate: CLLocationCoordinate2D) {}
+    func mapView(_ mapView: GMSMapView, didEndDragging marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didCloseInfoWindowOf marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didBeginDragging marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didDrag marker: GMSMarker) {}
+    func mapView(_ mapView: GMSMapView, didTapPOIWithPlaceID placeID: String, name: String, location: CLLocationCoordinate2D) {}
+    func mapViewDidStartTileRendering(_ mapView: GMSMapView) {}
+    func mapViewDidFinishTileRendering(_ mapView: GMSMapView) {}
+
+    func mapView(_ mapView: GMSMapView, markerInfoWindow marker: GMSMarker) -> UIView? {
+        return UIView()
+    }
+
+    func mapView(_ mapView: GMSMapView, markerInfoContents marker: GMSMarker) -> UIView? {
+        return UIView()
+    }
+
+    func didTapMyLocationButton(for mapView: GMSMapView) -> Bool {
+        return true
+    }
+
+    // MARK: - Equatable Conformance
+    static func == (lhs: MockMapDelegate, rhs: MockMapDelegate) -> Bool {
+        return true
+    }
+
+    // MARK: - NSObject Methods
+    func isEqual(_ object: Any?) -> Bool {
+        return true
+    }
+
+    func `self`() -> Self {
+        return self
+    }
+
+    func perform(_ aSelector: Selector!) -> Unmanaged<AnyObject>! {
+        return nil
+    }
+
+    func perform(_ aSelector: Selector!, with object: Any!) -> Unmanaged<AnyObject>! {
+        return nil
+    }
+
+    func perform(_ aSelector: Selector!, with object1: Any!, with object2: Any!) -> Unmanaged<AnyObject>! {
+        return nil
+    }
+
+    func isProxy() -> Bool {
+        return true
+    }
+
+    func isKind(of aClass: AnyClass) -> Bool {
+        return true
+    }
+
+    func isMember(of aClass: AnyClass) -> Bool {
+        return true
+    }
+
+    func conforms(to aProtocol: Protocol) -> Bool {
+        return true
+    }
+
+    func responds(to aSelector: Selector!) -> Bool {
+        return true
+    }
+}


### PR DESCRIPTION
### What's changing?

- Translate & Modernise `GMUClusterManagerTests` test class from Clustering test module.
- Code cov: 92.4%
- Source File: [GMUClusterManagerTest.m](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Tests/GoogleMapsUtilsObjCTests/unit/GMUClusterManagerTest.m)
 

### Validation:

<img width="1728" alt="Screenshot 2025-02-12 at 7 27 14 PM" src="https://github.com/user-attachments/assets/7b5fd747-1fea-4f03-9942-58e6fa6509d2" />
<img width="1728" alt="Screenshot 2025-02-12 at 7 27 26 PM" src="https://github.com/user-attachments/assets/c8439d28-3330-4edb-af79-857817a36f16" />
