### PR TITLE
refactor: Translate & Modernise `GMUDefaultClusterRendererTest` test class from Clustering test module. [code cov: 78.3%]

### DIFF
--- a/GoogleMapsUtils.xcodeproj/project.pbxproj
+++ b/GoogleMapsUtils.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		3EA5DDB72D5BA6D0009463B7 /* MockClusterManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */; };
 		3EA5DDB92D5BA6FF009463B7 /* MockMapDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */; };
 		3EBE77B22D61854500408141 /* GMUSimpleClusterAlgorithmTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBE77B12D61854400408141 /* GMUSimpleClusterAlgorithmTest.swift */; };
+		3EBE77BA2D6784FB00408141 /* MockGMSProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBE77B92D6784FA00408141 /* MockGMSProjection.swift */; };
+		3EBE77BC2D67851200408141 /* MockClusterIconGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBE77BB2D67851000408141 /* MockClusterIconGenerator.swift */; };
+		3EBE77BE2D67852700408141 /* GMUDefaultClusterRendererTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBE77BD2D67852500408141 /* GMUDefaultClusterRendererTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -250,6 +253,9 @@
 		3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClusterManagerDelegate.swift; sourceTree = "<group>"; };
 		3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMapDelegate.swift; sourceTree = "<group>"; };
 		3EBE77B12D61854400408141 /* GMUSimpleClusterAlgorithmTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUSimpleClusterAlgorithmTest.swift; sourceTree = "<group>"; };
+		3EBE77B92D6784FA00408141 /* MockGMSProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGMSProjection.swift; sourceTree = "<group>"; };
+		3EBE77BB2D67851000408141 /* MockClusterIconGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockClusterIconGenerator.swift; sourceTree = "<group>"; };
+		3EBE77BD2D67852500408141 /* GMUDefaultClusterRendererTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GMUDefaultClusterRendererTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -677,6 +683,8 @@
 		3EA5DC262D4DD755009463B7 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				3EBE77BB2D67851000408141 /* MockClusterIconGenerator.swift */,
+				3EBE77B92D6784FA00408141 /* MockGMSProjection.swift */,
 				3E3ABBEF2D5BC28D00D42DE6 /* MockGMSMapView.swift */,
 				3EA5DDB82D5BA6FE009463B7 /* MockMapDelegate.swift */,
 				3EA5DDB62D5BA6CF009463B7 /* MockClusterManagerDelegate.swift */,
@@ -692,6 +700,7 @@
 			isa = PBXGroup;
 			children = (
 				3EA5DC262D4DD755009463B7 /* Mocks */,
+				3EBE77BD2D67852500408141 /* GMUDefaultClusterRendererTest.swift */,
 				3EBE77B12D61854400408141 /* GMUSimpleClusterAlgorithmTest.swift */,
 				3EA5DDAE2D5BA5F8009463B7 /* GMUClusterManagerTests.swift */,
 				3EA5DC272D4DD755009463B7 /* GMUClusterAlgorithmTest.swift */,
@@ -1025,9 +1034,12 @@
 				3EA5DC5F2D4DD755009463B7 /* GMUGeometryCollectionTest.swift in Sources */,
 				3EA5DC602D4DD755009463B7 /* GMUNonHierarchicalDistanceBasedAlgorithmTest.swift in Sources */,
 				3EA5DC612D4DD755009463B7 /* GMUKMLParserTest.swift in Sources */,
+				3EBE77BA2D6784FB00408141 /* MockGMSProjection.swift in Sources */,
 				3E3ABBF02D5BC28F00D42DE6 /* MockGMSMapView.swift in Sources */,
 				3EA5DC622D4DD755009463B7 /* MockTest.swift in Sources */,
 				3EA5DC632D4DD755009463B7 /* GMUPointTest.swift in Sources */,
+				3EBE77BE2D67852700408141 /* GMUDefaultClusterRendererTest.swift in Sources */,
+				3EBE77BC2D67851200408141 /* MockClusterIconGenerator.swift in Sources */,
 				3EA5DC642D4DD755009463B7 /* GMUFeatureTest.swift in Sources */,
 				3EA5DC652D4DD755009463B7 /* GMULineStringTest.swift in Sources */,
 				3EA5DDB32D5BA68D009463B7 /* MockCluster.swift in Sources */,

--- a/Sources/GoogleMapsUtils/Clustering/View/DefaultRenderer/GMUDefaultClusterRenderer.swift
+++ b/Sources/GoogleMapsUtils/Clustering/View/DefaultRenderer/GMUDefaultClusterRenderer.swift
@@ -214,14 +214,13 @@ final class GMUDefaultClusterRenderer: GMUClusterRenderer {
                 continue
             }
 
-            guard let itemToNewClusterMap else { return }
             /// Find a candidate cluster to animate to.
             var toCluster: GMUCluster?
             if let cluster = marker.userData as? GMUCluster {
                 toCluster = overlappingCluster(for: cluster, itemMap: itemToNewClusterMap)
             } else {
                 let key = GMUWrappingDictionaryKey(object: userData)
-                toCluster = itemToNewClusterMap[key]
+                toCluster = itemToNewClusterMap?[key]
             }
             
             /// If there is not near by cluster to animate to, do not perform animation.

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUDefaultClusterRendererTest.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUDefaultClusterRendererTest.swift
@@ -1,0 +1,325 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import GoogleMaps
+
+@testable import GoogleMapsUtils
+
+class GMUDefaultClusterRendererTest: XCTestCase {
+
+    // MARK: - Properties
+    // Object under test.
+    private var renderer: GMUDefaultClusterRenderer!
+    var mapView: MockGMSMapView!
+    var camera: GMSCameraPosition!
+    var projection: MockGMSProjection!
+    var iconGenerator: GMUClusterIconGenerator!
+    private let kCameraPosition: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: CLLocationDegrees(-35), longitude: CLLocationDegrees(151))
+    private let kCameraZoom: Float = 1.0
+
+    // MARK: - Set Up
+    override func setUp() {
+        super.setUp()
+        GMSServices.provideAPIKey("MOCK_API_KEY")
+        mapView = MockGMSMapView()
+        camera = GMSCameraPosition(target: kCameraPosition, zoom: kCameraZoom)
+        mapView.mockCamera = camera
+
+        // Stub out projection property.
+        projection = MockGMSProjection()
+        let nearLeft = CLLocationCoordinate2D(latitude: kCameraPosition.latitude - 10,
+                                              longitude: kCameraPosition.longitude - 10)
+        let nearRight = CLLocationCoordinate2D(latitude: kCameraPosition.latitude - 10,
+                                               longitude: kCameraPosition.longitude + 10)
+        let farLeft = CLLocationCoordinate2D(latitude: kCameraPosition.latitude + 10,
+                                             longitude: kCameraPosition.longitude - 10)
+        let farRight = CLLocationCoordinate2D(latitude: kCameraPosition.latitude + 10,
+                                              longitude: kCameraPosition.longitude + 10)
+        
+        let visibleRegion = GMSVisibleRegion(nearLeft: nearLeft,
+                                             nearRight: nearRight,
+                                             farLeft: farLeft,
+                                             farRight: farRight)
+        projection.mockVisibleRegion = visibleRegion
+        mapView.mockProjection = projection
+
+        iconGenerator = MockClusterIconGenerator()
+        renderer = GMUDefaultClusterRenderer(
+            mapView: mapView,
+            clusterIconGenerator: iconGenerator)
+        renderer.animatesClusters = false
+    }
+
+    // MARK: - Teardown
+    override func tearDown() {
+        mapView = nil
+        renderer = nil
+        projection = nil
+        iconGenerator = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+    /// Large clusters should be rendered as 1 marker and not expanded.
+    func testRenderClustersLargeClustersNotExpanded() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        let cluster2 = clusterAroundPosition(
+            CLLocationCoordinate2DMake(
+                kCameraPosition.latitude + 1.0,
+                kCameraPosition.longitude),
+            count: 4)
+        clusters.append(cluster2)
+
+        // Act.
+        renderer.renderClusters(clusters)
+
+        // Assert.
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(markers.count, 2)
+        XCTAssertTrue(markers[0].userData is GMUCluster)
+        XCTAssertEqual(markers[0].map, mapView)
+
+        XCTAssertTrue(markers[1].userData is GMUCluster)
+        XCTAssertEqual(markers[1].map, mapView)
+    }
+
+    func testRenderClustersWithAnimationAndClearingAllMarkers() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        let cluster2 = clusterAroundPosition(
+            CLLocationCoordinate2DMake(
+                kCameraPosition.latitude + 1.0,
+                kCameraPosition.longitude),
+            count: 4)
+        clusters.append(cluster2)
+
+        // Act.
+        renderer.animatesClusters = true
+        renderer.renderClusters(clusters)
+        renderer.update()
+
+        // Assert.
+        let markers = renderer.currentActivemarkers
+        markers[0].position = CLLocationCoordinate2DMake(kCameraPosition.latitude + 20.0, kCameraPosition.longitude + 20.0)
+        renderer.clearMarkersAnimated(markers)
+        XCTAssertEqual(2, markers.count)
+    }
+
+    func testVisibleClustersFromClustersWithClustersArray() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        let cluster2 = clusterAroundPosition(
+            CLLocationCoordinate2DMake(
+                kCameraPosition.latitude + 1.0,
+                kCameraPosition.longitude),
+            count: 4)
+        clusters.append(cluster2)
+
+        // Act.
+        guard let clustersValue: [GMUCluster] = renderer.visibleClusters(from: clusters) else {
+            XCTFail("visibleClusters(from:) returned nil")
+            return
+        }
+
+        // Assert.
+        XCTAssertEqual(clusters.count, clustersValue.count, "Cluster count mismatch")
+
+        for (expected, actual) in zip(clusters, clustersValue) {
+            XCTAssertEqual(expected.position.latitude, actual.position.latitude, accuracy: 0.0001, "Latitude mismatch")
+            XCTAssertEqual(expected.position.longitude, actual.position.longitude, accuracy: 0.0001, "Longitude mismatch")
+            XCTAssertEqual(expected.count, actual.count, "Cluster count mismatch")
+            
+            // Optionally compare cluster items
+            XCTAssertEqual(expected.items.count, actual.items.count, "Cluster items count mismatch")
+        }
+    }
+    
+    func testAddingClusterItemsWithTitleAndSnippet() {
+        var clusters: [GMUCluster] = []
+        let cluster = clusterAroundPosition(kCameraPosition, count: 1, title: "Title", snippet: "Snippet")
+        clusters.append(cluster)
+
+        renderer.renderClusters(clusters)
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(1, markers.count)
+
+        let marker = markers[0]
+        XCTAssertTrue(marker.userData is GMUClusterItem)
+        XCTAssertEqual(mapView, marker.map)
+        XCTAssertEqual("Title", marker.title)
+        XCTAssertEqual("Snippet", marker.snippet)
+    }
+
+    /// Small clusters should be expanded into markers (one per cluster item).
+    func testRenderClustersSmallClustersExpanded() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 3)
+        clusters.append(cluster1)
+
+        // Act.
+        renderer.renderClusters(clusters)
+
+        // Assert.
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(markers.count, 3)
+        XCTAssertTrue(markers[0].userData is GMUClusterItem)
+        XCTAssertEqual(markers[0].map, mapView)
+
+        XCTAssertTrue(markers[1].userData is GMUClusterItem)
+        XCTAssertEqual(markers[1].map, mapView)
+
+        XCTAssertTrue(markers[2].userData is GMUClusterItem)
+        XCTAssertEqual(markers[2].map, mapView)
+    }
+
+    /// Clusters outside the camera's visible region should not be rendered.
+    func testRenderClustersInvisibleClustersNotRendered() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        // Outside cluster.
+        let cluster2 = clusterAroundPosition(
+            CLLocationCoordinate2DMake(
+                kCameraPosition.latitude + 20.0,
+                kCameraPosition.longitude + 20.0),
+            count: 10)
+        clusters.append(cluster2)
+
+        // Act.
+        renderer.renderClusters(clusters)
+
+        // Assert.
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(markers.count, 1)
+        XCTAssertEqual(markers[0].map, mapView)
+        // XCTAssertEqual(markers[0].userData, cluster1) // Only cluster1 is rendered
+    }
+
+    /// Clusters outside the camera's visible region should not be rendered.
+    func testRenderClustersPreviousMarkersRemovedFromMap() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        // Initial render.
+        renderer.renderClusters(clusters)
+        let previousMarkers = renderer.currentActivemarkers
+        XCTAssertEqual(previousMarkers.count, 1)
+        XCTAssertEqual(previousMarkers[0].map, mapView)
+
+        // Act: renderClusters again.
+        renderer.renderClusters(clusters)
+
+        // Assert.
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(markers.count, 1)
+        XCTAssertEqual(markers[0].map, mapView)
+
+        // Assert previous marker removed from map.
+        XCTAssertNil(previousMarkers[0].map)
+    }
+
+    func testShouldRenderAsClusterAtZoom() {
+        // Small cluster.
+        XCTAssertFalse(
+            renderer.shouldRenderAsCluster(clusterAroundPosition(kCameraPosition, count: 3), atZoom: 10))
+        
+        // Large cluster but high zoom.
+        XCTAssertFalse(
+            renderer.shouldRenderAsCluster(clusterAroundPosition(kCameraPosition, count: 10), atZoom: 21))
+        
+        // Large cluster and normal zoom.
+        XCTAssertTrue(
+            renderer.shouldRenderAsCluster(clusterAroundPosition(kCameraPosition, count: 10), atZoom: 20))
+        XCTAssertTrue(
+            renderer.shouldRenderAsCluster(clusterAroundPosition(kCameraPosition, count: 10), atZoom: 2))
+    }
+
+    func testDeallocMarkersCleared() {
+        // Arrange.
+        var clusters: [GMUCluster] = []
+        let cluster1 = clusterAroundPosition(kCameraPosition, count: 10)
+        clusters.append(cluster1)
+
+        let cluster2 = clusterAroundPosition(
+            CLLocationCoordinate2DMake(
+                kCameraPosition.latitude + 1.0,
+                kCameraPosition.longitude),
+            count: 4)
+        clusters.append(cluster2)
+        renderer.renderClusters(clusters)
+        let markers = renderer.currentActivemarkers
+        XCTAssertEqual(markers.count, 2)
+
+        // Act.
+        renderer = nil
+
+        // Assert markers are removed from the map.
+        XCTAssertEqual(markers.count, 2)
+        for marker in markers {
+            XCTAssertNil(marker.map)
+        }
+    }
+
+    // MARK:- Private
+    /// Returns a new cluster around a |position| with |count| items in it.
+    private func clusterAroundPosition(
+        _ position: CLLocationCoordinate2D,
+        count: Int
+    ) -> GMUStaticCluster {
+        return clusterAroundPosition(position, count: count, title: nil, snippet: nil)
+    }
+
+    /// Creates a cluster centered around a given position with a specified number of items.
+    ///
+    /// - Parameters:
+    ///   - position: The central coordinate for the cluster.
+    ///   - count: The number of items to add to the cluster.
+    ///   - title: The optional title for each cluster item.
+    ///   - snippet: The optional snippet for each cluster item.
+    /// - Returns: A `GMUStaticCluster` containing the generated cluster items.
+    private func clusterAroundPosition(
+        _ position: CLLocationCoordinate2D,
+        count: Int,
+        title: String?,
+        snippet: String?
+    ) -> GMUStaticCluster {
+        let cluster = GMUStaticCluster(position: position)
+        var count = count
+        while count > 0 {
+            count -= 1
+            let deltaLatitude = (Double(arc4random_uniform(200)) - 100.0) / 100.0
+            let deltaLongitude = (Double(arc4random_uniform(200)) - 100.0) / 100.0
+            let itemPosition = CLLocationCoordinate2DMake(CLLocationDegrees(position.latitude + deltaLatitude), CLLocationDegrees(position.longitude + deltaLongitude))
+            cluster.addItem(GMUTestClusterItem(position: itemPosition, title: title, snippet: snippet))
+        }
+        count -= 1
+        return cluster
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterIconGenerator.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterIconGenerator.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMaps
+
+@testable import GoogleMapsUtils
+
+/// A mock subclass of `GMUClusterIconGenerator` used for testing purposes.
+///
+final class MockClusterIconGenerator: GMUClusterIconGenerator {
+
+    // MARK: - Method
+    /// Generates an icon with the given size.
+    func iconForSize(_ size: Int) -> UIImage? {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        return renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: size, height: size))
+        }
+    }
+}

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSMapView.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSMapView.swift
@@ -14,14 +14,14 @@
 
 import GoogleMaps
 
-@testable import GoogleMapsUtils
-
 /// A mock subclass of `GMSMapView` used for testing purposes.
 final class MockGMSMapView: GMSMapView {
 
     // MARK: - Properties
     /// A mock camera position to override the default camera.
     var mockCamera: GMSCameraPosition?
+    /// A mock camera projection to override the default camera.
+    var mockProjection: GMSProjection?
 
     // MARK: - Overridden Properties
     /// Overrides the `camera` property to return the mock camera if set, otherwise calls the superclass implementation.
@@ -29,4 +29,10 @@ final class MockGMSMapView: GMSMapView {
         get { return mockCamera ?? super.camera }
         set { mockCamera = newValue }
     }
+
+    /// Overrides the `projection` property to return the mock projection.
+    override var projection: GMSProjection {
+        return mockProjection ?? super.projection
+    }
+
 }

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSProjection.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockGMSProjection.swift
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleMaps
+
+/// A mock subclass of `GMSProjection` used for testing purposes.
+///
+final class MockGMSProjection: GMSProjection {
+
+    // MARK: - Properties
+    var mockVisibleRegion: GMSVisibleRegion?
+
+    // MARK: - Overridden Properties
+    override func visibleRegion() -> GMSVisibleRegion {
+        return mockVisibleRegion ?? super.visibleRegion()
+    }
+}


### PR DESCRIPTION
### What's changing?

- Translate & Modernise `GMUDefaultClusterRendererTest` test class from Clustering test module.
- Code cov: 78.3%
- Source File: [GMUDefaultClusterRendererTest.m](https://github.com/googlemaps/google-maps-ios-utils/blob/main/Tests/GoogleMapsUtilsObjCTests/unit/GMUDefaultClusterRendererTest.m) 

### Validation:

<img width="1721" alt="Screenshot 2025-02-20 at 9 16 46 PM" src="https://github.com/user-attachments/assets/13eec4e8-ea17-455e-a389-355b799c0993" />

