### PR TITLE
fix: Update CI iOS version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,13 @@ jobs:
       run: |
         xcodebuild clean build analyze \
           -scheme GoogleMapsUtils -configuration Debug \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 15" \
+          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" \
           -disableAutomaticPackageResolution | xcpretty
 
     - name: Run unit tests on Swift Package
       run: |
         xcodebuild test -scheme GoogleMapsUtils \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 15" \
+          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" \
           -disableAutomaticPackageResolution
 
     - name: Upload test results to CodeCov
@@ -108,7 +108,7 @@ jobs:
       run: |
         xcodebuild -workspace samples/SwiftDemoApp/SwiftDemoApp.xcworkspace \
           -scheme SwiftDemoApp -configuration Debug \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 15" build | xcpretty
+          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" build | xcpretty
 
   build_objc_sample:
     name: Build Objective-C Sample App with CocoaPods locally
@@ -129,7 +129,7 @@ jobs:
       run: |
         xcodebuild -workspace samples/ObjCDemoApp/ObjCDemoApp.xcworkspace \
           -scheme ObjCDemoApp -configuration Debug \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 15" build | xcpretty
+          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" build | xcpretty
 
   test: # used as required status check
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What's changing?

- The Xcode runner is using Xcode 16.4, which ships iOS 18.x simulator runtimes. 
- [Update the CI script](https://github.com/googlemaps/google-maps-ios-utils/blob/ff420185b5df0a3043ae26aa0b263323f8fb5d7c/.github/workflows/build.yml#L49-L61) to 18.4.
- Failure: [link](https://github.com/googlemaps/google-maps-ios-utils/actions/runs/16908916293/job/47905191956)
