### PR TITLE
feat!: fix semantic versioning violation and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ range of applications using the [Google Maps SDK for iOS][sdk].
     [version](https://github.com/googlemaps/google-maps-ios-utils/releases)
     of the Maps SDK for iOS Utility Library that you want to use. For new projects, we recommend specifying the latest version and using the "Up to next Major" option. See Release Notes for [this library](https://github.com/googlemaps/google-maps-ios-utils/releases) and the [Maps SDK for iOS](https://developers.google.com/maps/documentation/ios-sdk/release-notes) to select the correct version for you.
 
-    - (Recommended) Version 6.x supports the Maps SDK for iOS v10.x and requires iOS 16.0+
+    - (Recommended) Version 6.x supports the Maps SDK for iOS v9.x
     - Version 5.0 supports the Maps SDK for iOS v8.x
     - Version 4.2.2 supports the Maps SDK for iOS v7.x
 


### PR DESCRIPTION
### What's changing?

- BREAKING CHANGE: Changes in v6.1.1 were breaking and should have been v7.0.0:
   - iOS deployment target: 15.0 → 16.0
   - GoogleMaps dependency: ~> 9.0 → ~> 10.0
   - PR: [link](https://github.com/googlemaps/google-maps-ios-utils/pull/546)
   - Release PR: [link](https://github.com/googlemaps/google-maps-ios-utils/pull/547)
- This commit also updates the README to accurately reflect current requirements.

Fixes #563  🦕
