### PR TITLE
fix(Cluster): Restore public access to clearItems and correct icon generator method signature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,13 @@ jobs:
       run: |
         xcodebuild clean build analyze \
           -scheme GoogleMapsUtils -configuration Debug \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" \
+          -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17" \
           -disableAutomaticPackageResolution | xcpretty
 
     - name: Run unit tests on Swift Package
       run: |
         xcodebuild test -scheme GoogleMapsUtils \
-          -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" \
+          -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17" \
           -disableAutomaticPackageResolution
 
     - name: Upload test results to CodeCov
@@ -103,7 +103,7 @@ jobs:
       run: |
           xcodebuild -workspace samples/SwiftDemoApp/SwiftDemoApp.xcworkspace \
             -scheme SwiftDemoApp -configuration Debug \
-            -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" build | xcpretty
+            -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17" build | xcpretty
 
   build_objc_sample:
     name: Build Objective-C Sample App with CocoaPods locally
@@ -124,7 +124,7 @@ jobs:
       run: |
           xcodebuild -workspace samples/ObjCDemoApp/ObjCDemoApp.xcworkspace \
             -scheme ObjCDemoApp -configuration Debug \
-            -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16" build | xcpretty
+            -destination "platform=iOS Simulator,OS=26.2,name=iPhone 17" build | xcpretty
 
   test: # used as required status check
     runs-on: ubuntu-latest

--- a/Sources/GoogleMapsUtils/Clustering/Manager/GMUClusterManager.swift
+++ b/Sources/GoogleMapsUtils/Clustering/Manager/GMUClusterManager.swift
@@ -129,7 +129,7 @@ public final class GMUClusterManager: NSObject, GMSMapViewDelegate {
 
     /// Clears all cluster items from the algorithm and requests clustering.
     ///
-    func clearItems() {
+    public func clearItems() {
         /// Clears all items from the clustering algorithm.
         algorithm.clearItems()
         /// Requests the clustering process to run after clearing items.

--- a/Sources/GoogleMapsUtils/Clustering/View/DefaultRenderer/GMUDefaultClusterRenderer.swift
+++ b/Sources/GoogleMapsUtils/Clustering/View/DefaultRenderer/GMUDefaultClusterRenderer.swift
@@ -357,7 +357,7 @@ public final class GMUDefaultClusterRenderer: GMUClusterRenderer {
                 }
             }
 
-            guard let icon: UIImage = clusterIconGenerator.iconForSize(cluster.count) else {
+            guard let icon: UIImage = clusterIconGenerator.icon(forSize: cluster.count) else {
                 return
             }
             let marker: GMSMarker = markerWithPosition(cluster.position, from: fromPosition, userData: cluster, clusterIcon: icon, animated: animated)

--- a/Sources/GoogleMapsUtils/Clustering/View/IconGenerator/GMUDefaultClusterIconGenerator.swift
+++ b/Sources/GoogleMapsUtils/Clustering/View/IconGenerator/GMUDefaultClusterIconGenerator.swift
@@ -122,7 +122,7 @@ public final class GMUDefaultClusterIconGenerator: GMUClusterIconGenerator {
     ///
     /// - Parameter size: The size for which the icon is generated.
     /// - Returns: A UIImage representing the icon for the specified size.
-    public func iconForSize(_ size: Int) -> UIImage? {
+    public func icon(forSize size: Int) -> UIImage? {
         /// Calls a method to get the appropriate bucket index
         let bucketIndex = bucketIndex(for: size)
         let text: String

--- a/Sources/GoogleMapsUtils/Clustering/View/Protocols/GMUClusterIconGenerator.swift
+++ b/Sources/GoogleMapsUtils/Clustering/View/Protocols/GMUClusterIconGenerator.swift
@@ -20,5 +20,5 @@ import UIKit
 public protocol GMUClusterIconGenerator {
 
     /// Generates an icon with the given size.
-    func iconForSize(_ size: Int) -> UIImage?
+    func icon(forSize size: Int) -> UIImage?
 }

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUDefaultClusterIconGeneratorTest.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/GMUDefaultClusterIconGeneratorTest.swift
@@ -56,40 +56,40 @@ final class GMUDefaultClusterIconGeneratorTest: XCTestCase {
     }
 
     func testIconForSizeSmallerThanFirstBucket() {
-        let result = generator.iconForSize(5)
+        let result = generator.icon(forSize: 5)
         XCTAssertNotNil(result, "Expected a valid image to be returned for size smaller than the first bucket.")
         XCTAssertEqual(generator.iconWithImage(for: "5", with: backgroundImages[0]), result)
     }
 
     func testIconForSizeMatchingBucketValue() {
-        let result = generator.iconForSize(11)
+        let result = generator.icon(forSize: 11)
         XCTAssertNotNil(result, "Expected a valid image to be returned for size matching the bucket value.")
         XCTAssertEqual(generator.iconWithImage(for: "10+", with: backgroundImages[1]), result)
     }
 
     func testIconForSizeExceedingBucketValue() {
-        let result = generator.iconForSize(51)
+        let result = generator.icon(forSize: 51)
         XCTAssertNotNil(result, "Expected a valid image to be returned for size exceeding a bucket value.")
         XCTAssertEqual(generator.iconWithImage(for: "50+", with: backgroundImages[2]), result)
     }
 
     func testIconForSizeWithBackgroundImages() {
         generator.backgroundImages = backgroundImages
-        let result = generator.iconForSize(100)
+        let result = generator.icon(forSize: 100)
         XCTAssertNotNil(result, "Expected a valid image to be returned when no background images are provided.")
         XCTAssertEqual(generator.iconWithIndex(for: "100+", with: 3), result)
     }
 
     func testIconForSizeWithNoBackgroundImages() {
         generator.backgroundImages = nil
-        let result = generator.iconForSize(100)
+        let result = generator.icon(forSize: 100)
         XCTAssertNotNil(result, "Expected a valid image to be returned when no background images are provided.")
         XCTAssertEqual(generator.iconWithIndex(for: "100+", with: 3), result)
     }
 
     func testIconForSizeSmallerThanFirstBucketNoBackgroundImages() {
         generator.backgroundImages = nil
-        let result = generator.iconForSize(5)
+        let result = generator.icon(forSize: 5)
         XCTAssertNotNil(result, "Expected a valid image to be returned for size smaller than the first bucket without background images.")
         XCTAssertEqual(generator.iconWithIndex(for: "5", with: 0), result)
     }

--- a/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterIconGenerator.swift
+++ b/Tests/GoogleMapsUtilsTests/unit/Clustering/Mocks/MockClusterIconGenerator.swift
@@ -22,7 +22,7 @@ final class MockClusterIconGenerator: GMUClusterIconGenerator {
 
     // MARK: - Method
     /// Generates an icon with the given size.
-    func iconForSize(_ size: Int) -> UIImage? {
+    func icon(forSize size: Int) -> UIImage? {
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
         return renderer.image { context in
             UIColor.red.setFill()


### PR DESCRIPTION
### What's changing?

- Restore public access to clearItems and correct icon generator method signature
  - Make GMUClusterManager.clearItems() public for dynamic framework compatibility
  - Update GMUClusterIconGenerator protocol method from iconForSize(_:) to icon(forSize:) to match original Objective-C API
  - Update all implementations and call sites to use correct method signature

Fixes [link](https://github.com/googlemaps/google-maps-ios-utils/issues/473#issuecomment-4076846023)
