### PR TITLE
#574 Update Google Maps SDK dependency version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/googlemaps/ios-maps-sdk",
-      from: "10.0.0"),
+      "10.0.0"..<"12.0.0"),
     .package(
       url: "https://github.com/erikdoe/ocmock.git",
       revision: "fe1661a3efed11831a6452f4b1a0c5e6ddc08c3d"),


### PR DESCRIPTION
Trying to update to Maps SDK 11.0.0 give the following error:
```
Failed to resolve dependencies Dependencies could not be resolved because root depends on 'google-maps-ios-utils' 7.1.0.
'google-maps-ios-utils' 7.1.0 cannot be used because 'google-maps-ios-utils' 7.1.0 depends on 'ios-maps-sdk' 10.0.0..<11.0.0 and root depends on 'ios-maps-sdk' 11.0.0.
```

Currently google-maps-ios-utils pins the major version 10.x.x for ios-maps-sdk. Changing the pinning to `10.0.0..<12.0.0` in the Package.swift, the library appears to build and function just fine with the new 11.0.0 version of ios-maps-sdk.  

Fixes #574 🦕
